### PR TITLE
Adding Airflow and some container stuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,45 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@0.1.15
+  aws-ecr: circleci/aws-ecr@6.2.0
+  aws-ecs: circleci/aws-ecs@0.0.11
+  aws-s3: circleci/aws-s3@1.0.11
+
+parameters:
+  # Workflow triggers
+  build_and_deploy_service:
+    type: boolean
+    default: false
+  deploy_service:
+    type: boolean
+    default: false
+  promote_service:
+    type: boolean
+    default: false
+  sync_dags:
+    type: boolean
+    default: false
+
+  dockerfile:
+    type: string
+    default: ""
+  ecs_service_name:
+    type: string
+    default: ""
+  ecs_task_definition:
+    type: string
+    default: ""
+  environment:
+    type: string
+    default: ""
+  repo:
+    type: string
+    default: ""
+  service_name:
+    type: string
+    default: ""
+
 aliases:
   - &filter_sniffles_tag_staging
     tags:
@@ -13,10 +51,21 @@ aliases:
       only: /v0\.1\.[0-9]+_prod_[a-zA-Z0-9]+$/
     branches:
       ignore: /.*/
+  - &aws_creds
+      aws-access-key-id: AWS_ACCESS_KEY_ID
+      aws-secret-access-key: AWS_SECRET_ACCESS_KEY
 
 const: &const
   PROD_SERVER: "https://api.auderenow.io/api"
   STAGING_SERVER: "https://api.staging.auderenow.io/api"
+
+ecs_hosts: &ecs_hosts
+  staging: STAGING_ECS_CLUSTER
+  prod: PRODUCTION_ECS_CLUSTER
+
+dag_buckets: &dag_buckets
+  staging: STAGING_DAG_BUCKET
+  prod: PRODUCTION_DAG_BUCKET
 
 defaults: &defaults
   docker:
@@ -97,7 +146,6 @@ set_firebase_config: &set_firebase_config
     esac
     grep project_id android/app/google-services.json
 
-version: 2
 jobs:
   build:
     <<: *defaults
@@ -175,7 +223,7 @@ jobs:
             sudo apt-get install -y postgresql-client
             # Wait up to a minute for port 5432 to open
             for i in $(seq 60); do (! nc -z localhost 5432) && sleep 1 || break; done
-            psql "$TEST_DATABASE_URL" <<EOF
+            psql "$TEST_DATABASE_URL" \<<EOF
               CREATE DATABASE test_pii;
               CREATE DATABASE test_nonpii;
             EOF
@@ -665,8 +713,62 @@ jobs:
       - store_artifacts:
           path: /tmp/repo/EbPhotoStore/android/app/build/outputs/bundle/release
 
+  add_image_tag:
+    <<: *defaults
+    parameters:
+      repo:
+        type: string
+      current_tag:
+        type: string
+      additional_tag:
+        type: string
+    steps:
+      - run:
+          name: Copy image manifest to env
+          command: |
+            MANIFEST=$(aws ecr batch-get-image --repository-name << parameters.repo >> --image-ids imageTag=<< parameters.current_tag >> --query 'images[].imageManifest' --output text)
+      - run:
+          name: Put additional image tag
+          command: |
+            aws ecr put-image --repository-name << parameters.repo >> --image-tag << parameters.additional_tag >> --image-manifest "$MANIFEST"
+
+  aws-cli:
+    executor: aws-cli/default
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          <<: *aws_creds
+
+  build_service:
+    <<: *defaults
+    parameters:
+      service_name:
+        type: string
+    working_directory: /tmp/repo
+    steps:
+      - checkout:
+          path: /tmp/repo
+      - run:
+          name: Build container service
+          command: |
+            ./scripts/build_service << parameters.service_name >>
+
+  sync_dags_bucket:
+    <<: *defaults
+    parameters:
+      bucket:
+        type: string
+    working_directory: /tmp/repo
+    steps:
+      - checkout:
+          path: /tmp/repo
+      - aws-s3/sync:
+          <<: *aws_creds
+          from: pipeline/workflows
+          to: dag_buckets['<< pipeline.parameters.environment >>']
+
 workflows:
-  version: 2
   build_and_publish:
     jobs:
       - build:
@@ -691,3 +793,46 @@ workflows:
                 - master
     jobs:
       - snyk_scan
+  build_and_deploy_service:
+    when: << pipeline.parameters.build_and_deploy_service >>
+    jobs:
+      - build_service:
+          service_name: << pipeline.parameters.service_name >>
+      - aws-ecr/build-and-push-image:
+          <<: *aws_creds
+          dockerfile: << pipeline.parameters.dockerfile >>
+          repo: << pipeline.parameters.repo >>
+          tag: staging
+      - add_image_tag:
+          repo: << pipeline.parameters.repo >>
+          current_tag: staging
+          additional_tag: ${CIRCLE_SHA1}
+      - aws-ecs/deploy-service-update:
+          family: << pipeline.parameters.ecs_task_definition >>
+          cluster-name: STAGING_ECS_CLUSTER
+          service-name: << pipeline.parameters.ecs_service_name >>
+  deploy_service:
+    when: << pipeline.parameters.deploy_service >>
+    jobs:
+      - aws-cli
+      - aws-ecs/deploy-service-update:
+          family: << pipeline.parameters.ecs_task_definition >>
+          cluster-name: ecs_hosts['<< pipeline.parameters.environment >>']
+          service-name: << pipeline.parameters.ecs_service_name >>
+  promote_service:
+    when: << pipeline.parameters.promote_service >>
+    jobs:
+      - aws-cli
+      - add_image_tag:
+          repo: << pipeline.parameters.repo >>
+          current_tag: staging
+          additional_tag: prod
+      - aws-ecs/deploy-service-update:
+          family: << pipeline.parameters.ecs_task_definition >>
+          cluster-name: PRODUCTION_ECS_CLUSTER
+          service-name: << pipeline.parameters.ecs_service_name >>
+  sync_dags:
+    when: << pipeline.parameters.sync_dags >>
+    jobs:
+      - sync_dags_bucket:
+          bucket: dag_buckets['<< pipeline.parameters.environment >>']

--- a/pipeline/airflow/Dockerfile
+++ b/pipeline/airflow/Dockerfile
@@ -1,0 +1,6 @@
+FROM puckel/docker-airflow:1.10.4
+
+USER root
+RUN pip install apache-airflow[google_auth]
+
+USER airflow

--- a/pipeline/workflows/tuto.py
+++ b/pipeline/workflows/tuto.py
@@ -1,0 +1,48 @@
+"""
+Code that goes along with the Airflow located at:
+http://airflow.readthedocs.org/en/latest/tutorial.html
+"""
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from datetime import datetime, timedelta
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 6, 1),
+    "email": ["airflow@airflow.com"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    # 'queue': 'bash_queue',
+    # 'pool': 'backfill',
+    # 'priority_weight': 10,
+    # 'end_date': datetime(2016, 1, 1),
+}
+
+dag = DAG("tutorial", default_args=default_args, schedule_interval=timedelta(1))
+
+# t1, t2 and t3 are examples of tasks created by instantiating operators
+t1 = BashOperator(task_id="print_date", bash_command="date", dag=dag)
+
+t2 = BashOperator(task_id="sleep", bash_command="sleep 5", retries=3, dag=dag)
+
+templated_command = """
+    {% for i in range(5) %}
+        echo "{{ ds }}"
+        echo "{{ macros.ds_add(ds, 7)}}"
+        echo "{{ params.my_param }}"
+    {% endfor %}
+"""
+
+t3 = BashOperator(
+    task_id="templated",
+    bash_command=templated_command,
+    params={"my_param": "Parameter I passed in"},
+    dag=dag,
+)
+
+t2.set_upstream(t1)
+t3.set_upstream(t1)

--- a/scripts/build-and-deploy-service
+++ b/scripts/build-and-deploy-service
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright (c) 2019 by Audere
+#
+# Use of this source code is governed by an MIT-style license that
+# can be found in the LICENSE file distributed with this file.
+
+set -euo pipefail
+SELF_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+function usage() {
+  echo 1>&2 "$*"
+  echo 1>&2 "Usage:"
+  echo 1>&2 "  build-and-deploy-service <service>"
+  echo 1>&2 ""
+  echo 1>&2 "<service> is the name of the service to be built"
+  echo 1>&2 ""
+  echo 1>&2 "Example:"
+  echo 1>&2 "  build-and-deploy-service airflow"
+  echo 1>&2 ""
+  exit 1
+}
+
+case "$#" in
+  1) readonly service="$1";;
+  *) usage "Expected 1 argument, got $#.";;
+esac
+
+if [[ -z "$CIRCLECI_TOKEN" ]]; then
+  usage "CircleCI token is unset"
+fi
+
+if [[ -z $(jq .staging.$service $SELF_DIR/service-registry.json) ]]; then
+  usage "Expected a defined service, got $service."
+fi
+
+dockerfile=$(jq .staging.$service.dockerfile $SELF_DIR/service-registry.json)
+ecs_service_name=$(jq .staging.$service.ecs_service_name $SELF_DIR/service-registry.json)
+ecs_task_definition=$(jq .staging.$service.ecs_task_definition $SELF_DIR/service-registry.json)
+repo=$(jq .staging.$service.repo $SELF_DIR/service-registry.json)
+
+body=$(cat <<EOF
+{
+  "parameters": {
+    "build_and_deploy_service": "true",
+    "service_name": "$service",
+    "dockerfile": "$dockerfile",
+    "repo": "$repo",
+    "ecs_service_name": "$ecs_service_name",
+    "ecs_task_definition": "$ecs_task_definition"
+  }
+}
+EOF
+)
+
+curl -u ${CIRCLECI_TOKEN} -X POST --header "Content-Type: application/json" -d '$body' https://circleci.com/api/v2/project/gh/AudereNow/audere/pipeline
+
+echo ""

--- a/scripts/build-service
+++ b/scripts/build-service
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) 2019 by Audere
+#
+# Use of this source code is governed by an MIT-style license that
+# can be found in the LICENSE file distributed with this file.
+
+set -euo pipefail
+
+function usage() {
+  echo 1>&2 "$*"
+  echo 1>&2 "Usage:"
+  echo 1>&2 "  build-service <service>"
+  echo 1>&2 ""
+  echo 1>&2 "<service> is the name of the service to be built"
+  echo 1>&2 ""
+  echo 1>&2 "Example:"
+  echo 1>&2 "  build-service fluapi"
+  echo 1>&2 ""
+  exit 1
+}
+
+case "$#" in
+  1) readonly service="$1";;
+  *) usage "Expected 1 argument, got $#.";;
+esac
+
+case "$service" in
+  fluapi)
+    (set -x
+    cd FluApi
+    yarn install
+    yarn build
+    )
+    ;;
+  *) usage "Expected a defined service, got $service.";;
+esac
+
+echo ""

--- a/scripts/deploy-service
+++ b/scripts/deploy-service
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright (c) 2019 by Audere
+#
+# Use of this source code is governed by an MIT-style license that
+# can be found in the LICENSE file distributed with this file.
+
+set -euo pipefail
+SELF_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+function usage() {
+  echo 1>&2 "$*"
+  echo 1>&2 "Usage:"
+  echo 1>&2 "  deploy-service <service> [<environment>]"
+  echo 1>&2 ""
+  echo 1>&2 "<service> is the name of the service to be deployed"
+  echo 1>&2 "<environment> can be one of 'staging' or 'prod', defaults to 'staging'"
+  echo 1>&2 ""
+  echo 1>&2 "Example:"
+  echo 1>&2 "  deploy-service airflow-webserver"
+  echo 1>&2 ""
+  exit 1
+}
+
+case "$#" in
+  1)
+    readonly service="$1"
+    readonly environment="staging"
+    ;;
+  2)
+    readonly service="$1"
+    readonly environment="$2"
+    ;;
+  *) usage "Expected 1 or 2 arguments, got $#.";;
+esac
+
+if [[ "$environment" =~ ^(staging|prod)$ ]]; then
+  usage "Environment must be one of 'staging' or 'prod'"
+fi
+
+if [[ -z "$CIRCLECI_TOKEN" ]]; then
+  usage "CircleCI token is unset"
+fi
+
+if [[ -z $(jq .staging.$service $SELF_DIR/service-registry.json) ]]; then
+  usage "Expected a defined service, got $service."
+fi
+
+ecs_service_name=$(jq .staging.$service.ecs_service_name $SELF_DIR/service-registry.json)
+ecs_task_definition=$(jq .staging.$service.ecs_task_definition $SELF_DIR/service-registry.json)
+
+body=$(cat <<EOF
+{
+  "parameters": {
+    "deploy_service": "true",
+    "environment": $environment
+    "ecs_service_name": "$ecs_service_name",
+    "ecs_task_definition": "$ecs_task_definition"
+  }
+}
+EOF
+)
+
+curl -u ${CIRCLECI_TOKEN} -X POST --header "Content-Type: application/json" -d '$body' https://circleci.com/api/v2/project/gh/AudereNow/audere/pipeline
+
+echo ""

--- a/scripts/promote-service
+++ b/scripts/promote-service
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) 2019 by Audere
+#
+# Use of this source code is governed by an MIT-style license that
+# can be found in the LICENSE file distributed with this file.
+
+set -euo pipefail
+SELF_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+function usage() {
+  echo 1>&2 "$*"
+  echo 1>&2 "Usage:"
+  echo 1>&2 "  promote-service <service>"
+  echo 1>&2 ""
+  echo 1>&2 "<service> is the name of the service to be promoted"
+  echo 1>&2 ""
+  echo 1>&2 "Example:"
+  echo 1>&2 "  promote-service airflow"
+  echo 1>&2 ""
+  exit 1
+}
+
+case "$#" in
+  1) readonly service="$1";;
+  *) usage "Expected 1 argument, got $#.";;
+esac
+
+if [[ -z "$CIRCLECI_TOKEN" ]]; then
+  usage "CircleCI token is unset"
+fi
+
+if [[ -z $(jq .staging.$service $SELF_DIR/service-registry.json) ]]; then
+  usage "Expected a defined service, got $service."
+fi
+
+ecs_service_name=$(jq .staging.$service.ecs_service_name $SELF_DIR/service-registry.json)
+ecs_task_definition=$(jq .staging.$service.ecs_task_definition $SELF_DIR/service-registry.json)
+repo=$(jq .staging.$service.repo $SELF_DIR/service-registry.json)
+
+body=$(cat <<EOF
+{
+  "parameters": {
+    "promote_service": "true",
+    "ecs_service_name": "$ecs_service_name",
+    "ecs_task_definition": "$ecs_task_definition",
+    "repo": "$repo"
+  }
+}
+EOF
+)
+
+curl -u ${CIRCLECI_TOKEN} -X POST --header "Content-Type: application/json" -d '$body' https://circleci.com/api/v2/project/gh/AudereNow/audere/pipeline
+
+echo ""

--- a/scripts/service-registry.json
+++ b/scripts/service-registry.json
@@ -1,0 +1,54 @@
+{
+  "prod": {
+    "airflow-webserver": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-webserver-staging",
+      "ecs_task_definition": "airflow-webserver-staging",
+      "repo": "airflow"
+    },
+    "airflow-scheduler": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-scheduler-staging",
+      "ecs_task_definition": "airflow-scheduler-staging",
+      "repo": "airflow"
+    },
+    "airflow-worker": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-worker-staging",
+      "ecs_task_definition": "airflow-worker-staging",
+      "repo": "airflow"
+    },
+    "airflow-flower": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-flower-staging",
+      "ecs_task_definition": "airflow-flower-staging",
+      "repo": "airflow"
+    }
+  },
+  "staging": {
+    "airflow-webserver": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-webserver-prod",
+      "ecs_task_definition": "airflow-webserver-prod",
+      "repo": "airflow"
+    },
+    "airflow-scheduler": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-scheduler-prod",
+      "ecs_task_definition": "airflow-scheduler-prod",
+      "repo": "airflow"
+    },
+    "airflow-worker": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-worker-prod",
+      "ecs_task_definition": "airflow-worker-prod",
+      "repo": "airflow"
+    },
+    "airflow-flower": {
+      "dockerfile": "pipeline/airflow/Dockerfile",
+      "ecs_service_name": "airflow-flower-prod",
+      "ecs_task_definition": "airflow-flower-prod",
+      "repo": "airflow"
+    }
+  }
+}

--- a/terraform/global/1-policy/main.tf
+++ b/terraform/global/1-policy/main.tf
@@ -125,11 +125,11 @@ resource "aws_kms_alias" "ssm_parameters" {
 // --------------------------------------------------------------------------------
 // ECR image push user
 
-resource "aws_iam_user" "ecr_push" {
-  name = "ecr-push"
+resource "aws_iam_user" "build_user" {
+  name = "build-user"
 }
 
-resource "aws_iam_user_policy_attachment" "ecr_push" {
+resource "aws_iam_user_policy_attachment" "build_user" {
   user       = "${aws_iam_user.ecr_push.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }
@@ -145,11 +145,11 @@ data "aws_iam_policy_document" "create_ecr_repository_document" {
 }
 
 resource "aws_iam_policy" "create_ecr_repository_policy" {
-  name   = "ecr-push-create-repo"
+  name   = "ecr-create-repo"
   policy = "${data.aws_iam_policy_document.create_ecr_repository_document.json}"
 }
 
 resource "aws_iam_user_policy_attachment" "create_ecr_repository_attachment" {
-  user       = "${aws_iam_user.ecr_push.name}"
+  user       = "${aws_iam_user.build_user.name}"
   policy_arn = "${aws_iam_policy.create_ecr_repository_policy.arn}"
 }

--- a/terraform/global/1-policy/outputs.tf
+++ b/terraform/global/1-policy/outputs.tf
@@ -15,8 +15,8 @@ output "database_log_archive_bucket_name" {
   value = "${aws_s3_bucket.database_log_archive.id}"
 }
 
-output "ecr_push_user" {
-  value = "${aws_iam_user.ecr_push.name}"
+output "build_user" {
+  value = "${aws_iam_user.build_user.name}"
 }
 
 output "ecs_service_linked_role_arn" {

--- a/terraform/modules/airflow/airflow.json
+++ b/terraform/modules/airflow/airflow.json
@@ -1,0 +1,81 @@
+{
+  "name": "${container_name}",
+  "image": "${image}",
+  "essential": true,
+  "portMappings": [
+    {
+      "containerPort": "${container_port}",
+      "hostPort": "${host_port}"
+    }
+  ],
+  "command": [
+    "${command}"
+  ],
+  "environment": [
+    {
+      "name": "AIRFLOW__CORE__DAGS_FOLDER",
+      "value": "/s3fs/dags"
+    },
+    {
+      "name": "REDIS_HOST",
+      "value": "${redis_host}"
+    },
+    {
+      "name": "REDIS_PORT",
+      "value": "${redis_port}"
+    },
+    {
+      "name": "POSTGRES_HOST",
+      "value": "${postgres_host}"
+    },
+    {
+      "name": "POSTGRES_PORT",
+      "value": "${postgres_port}"
+    },
+    {
+        "name": "POSTGRES_DB",
+        "value": "airflow"
+    },
+    {
+      "name": "ENABLE_REMOTE_LOGGING",
+      "value": "False"
+    }
+  ],
+  "secrets": [
+    {
+      "name": "FERNET_KEY",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${fernet_key}"
+    },
+    {
+      "name": "POSTGRES_USER",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${postgres_user_key}"
+    },
+    {
+      "name": "POSTGRES_PASSWORD",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${postgres_pass_key}"
+    }
+  ],
+  "logConfiguration": {
+    "logDriver": "awslogs",
+    "options": {
+      "awslogs-group": "airflow-${var.environment}",
+      "awslogs-region": "${region}",
+      "awslogs-stream-prefix": "${command}",
+      "awslogs-create-group": "true"
+    }
+  },
+  "mountPoints": [
+    {
+      "sourceVolume": "s3fs-dags",
+      "containerPath": "/s3fs/dags"
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/s3fs/dags"
+      },
+      "name": "s3fs-dags"
+    }
+  ]
+}

--- a/terraform/modules/airflow/airflow_no_ports.json
+++ b/terraform/modules/airflow/airflow_no_ports.json
@@ -1,0 +1,75 @@
+{
+  "name": "${container_name}",
+  "image": "${image}",
+  "essential": true,
+  "command": [
+    "${command}"
+  ],
+  "environment": [
+    {
+      "name": "AIRFLOW__CORE__DAGS_FOLDER",
+      "value": "/s3fs/dags"
+    },
+    {
+      "name": "REDIS_HOST",
+      "value": "${redis_host}"
+    },
+    {
+      "name": "REDIS_PORT",
+      "value": "${redis_port}"
+    },
+    {
+      "name": "POSTGRES_HOST",
+      "value": "${postgres_host}"
+    },
+    {
+      "name": "POSTGRES_PORT",
+      "value": "${postgres_port}"
+    },
+    {
+        "name": "POSTGRES_DB",
+        "value": "airflow"
+    },
+    {
+      "name": "ENABLE_REMOTE_LOGGING",
+      "value": "False"
+    }
+  ],
+  "secrets": [
+    {
+      "name": "FERNET_KEY",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${fernet_key}"
+    },
+    {
+      "name": "POSTGRES_USER",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${db_user_key}"
+    },
+    {
+      "name": "POSTGRES_PASSWORD",
+      "valueFrom": "arn:aws:ssm:${region}:${account}:parameter/${db_pass_key}"
+    }
+  ],
+  "logConfiguration": {
+    "logDriver": "awslogs",
+    "options": {
+      "awslogs-group": "airflow-${var.environment}",
+      "awslogs-region": "${region}",
+      "awslogs-stream-prefix": "${command}",
+      "awslogs-create-group": "true"
+    }
+  },
+  "mountPoints": [
+    {
+      "sourceVolume": "s3fs-dags",
+      "containerPath": "/s3fs/dags"
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/s3fs/dags"
+      },
+      "name": "s3fs-dags"
+    }
+  ]
+}

--- a/terraform/modules/airflow/main.tf
+++ b/terraform/modules/airflow/main.tf
@@ -1,0 +1,251 @@
+// Copyright (c) 2019 by Audere
+//
+// Use of this source code is governed by an MIT-style license that
+// can be found in the LICENSE file distributed with this file.
+
+locals {
+  airflow_subdomains = {
+    prod = "airflow"
+    staging = "airflow.staging"
+  }
+  airflow_subdomain = "${local.reporting_subdomains["${var.environment}"]}"
+  ecr_registry = "${var.account}.dkr.ecr.${var.region}.amazonaws.com"
+}
+
+// --------------------------------------------------------------------------------
+// Load balancer
+
+resource "aws_lb" "airflow_lb" {
+  name = "airflow-${var.environment}"
+  subnets = [
+    "${var.app_subnet_id}",
+    "${var.app_b_subnet_id}",
+  ]
+  security_groups = [
+    "${var.public_http_sg_id}",
+    "${var.ecs_dynamic_client_sg_id}",
+  ]
+
+  access_logs {
+    bucket = "${var.elb_logs_bucket_id}"
+    bucket_prefix = "reporting"
+    enabled = true
+  }
+}
+
+resource "aws_lb_target_group" "webserver" {
+  name = "airflow-webserver-${var.environment}"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${var.vpc_id}"
+}
+
+resource "aws_lb_target_group" "flower" {
+  name = "airflow-flower-${var.environment}"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${varr.vpc_id}"
+}
+
+resource "aws_lb_listener" "airflow_listener" {
+  load_balancer_arn = "${aws_lb.airflow_lb.id}"
+  port = 443
+  protocol = "HTTPS"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.webserver.id}"
+    type = "forward"
+  }
+}
+
+resource "aws_lb_listener_rule" "flower_routing" {
+  listener_arn = "${aws_lb_listener.airflow_listener.arn}"
+
+  action {
+    target_group_arn = "${aws_lb_target_group.flower.arn}"
+    type = "forward"
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/flower/*"]
+  }
+}
+
+resource "aws_route53_record" "airflow_record" {
+  zone_id = "${var.auderenow_route53_zone_id}"
+  name = "${local.airflow_subdomain}.${var.auderenow_route53_zone_name}"
+  type = "A"
+
+  alias {
+    name = "${aws_lb.airflow_lb.dns_name}"
+    zone_id = "${aws_lb.airflow_lb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+// --------------------------------------------------------------------------------
+// Celery Redis (task queue)
+
+resource "aws_elasticache_cluster" "celery_queue" {
+  cluster_id = "airflow-celery-${var.environment}"
+  engine = "redis"
+  node_type = "cache.t2.small"
+  num_cache_nodes = 1
+  parameter_group_name = "default.redis5.0"
+  port = 6379
+  security_group_ids = ["${var.redis_server_sg_id}"]
+}
+
+// --------------------------------------------------------------------------------
+// Airflow tasks
+
+data "template_file" "webserver" {
+  template = "${file("${path.module}/airflow.json")}"
+
+  vars {
+    account = "${var.account}"
+    container_name = "airflow-webserver-${var.environment}"
+    container_port = 8080
+    fernet_key = "airflow-${var.environment}.fernet"
+    host_port = 0
+    redis_host = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.address}"
+    redis_port = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.port}"
+    postgres_host = "${var.airflow_database_address}"
+    postgres_pass_key = "airflow-${var.environment}.pass"
+    postgres_user_key = "airflow-${var.environment}.user"
+    environment = "${var.environment}"
+    image = "${local.ecr_registry}/airflow:${var.environment}"
+    command = "webserver"
+    region = "${var.region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "webserver" {
+  family = "airflow-webserver-${var.environment}"
+  container_definitions = "${data.template_file.webserver.rendered}"
+  execution_role_arn = "${aws_iam_role.airflow_task_execution_role.arn}"
+}
+
+resource "aws_ecs_service" "webserver" {
+  name = "airflow-webserver-${var.environment}"
+  cluster = "${var.ecs_cluster_id}"
+  task_definition = "${aws_ecs_task_definition.webserver.arn}"
+  desired_count = 1
+  iam_role = "${var.ecs_service_linked_role_arn}"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.webserver.id}"
+    container_name = "airflow-webserver-${var.environment}"
+    container_port = 8080
+  }
+}
+
+data "template_file" "scheduler" {
+  template = "${file("${path.module}/airflow.json")}"
+
+  vars {
+    account = "${var.account}"
+    container_name = "airflow-scheduler-${var.environment}"
+    container_port = 8793
+    fernet_key = "airflow-${var.environment}.fernet"
+    host_port = 0
+    redis_host = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.address}"
+    redis_port = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.port}"
+    postgres_host = "${var.airflow_database_address}"
+    postgres_pass_key = "airflow-${var.environment}.pass"
+    postgres_user_key = "airflow-${var.environment}.user"
+    environment = "${var.environment}"
+    image = "${local.ecr_registry}/airflow:${var.environment}"
+    command = "scheduler"
+    region = "${var.region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "scheduler" {
+  family = "airflow-scheduler-${var.environment}"
+  container_definitions = "${data.template_file.scheduler.rendered}"
+  execution_role_arn = "${aws_iam_role.airflow_task_execution_role.arn}"
+}
+
+resource "aws_ecs_service" "scheduler" {
+  name = "airflow-scheduler-${var.environment}"
+  cluster = "${var.ecs_cluster_id}"
+  task_definition = "${aws_ecs_task_definition.scheduler.arn}"
+  desired_count = 1
+  iam_role = "${var.ecs_service_linked_role_arn}"
+}
+
+data "template_file" "worker" {
+  template = "${file("${path.module}/airflow_no_ports.json")}"
+
+  vars {
+    account = "${var.account}"
+    container_name = "airflow-worker-${var.environment}"
+    fernet_key = "airflow-${var.environment}.fernet"
+    redis_host = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.address}"
+    redis_port = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.port}"
+    postgres_host = "${var.airflow_database_address}"
+    postgres_pass_key = "airflow-${var.environment}.pass"
+    postgres_user_key = "airflow-${var.environment}.user"
+    environment = "${var.environment}"
+    image = "${local.ecr_registry}/airflow:${var.environment}"
+    command = "worker"
+    region = "${var.region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "worker" {
+  family = "airflow-worker-${var.environment}"
+  container_definitions = "${data.template_file.worker.rendered}"
+  execution_role_arn = "${aws_iam_role.airflow_task_execution_role.arn}"
+}
+
+resource "aws_ecs_service" "worker" {
+  name = "airflow-worker-${var.environment}"
+  cluster = "${var.ecs_cluster_id}"
+  task_definition = "${aws_ecs_task_definition.scheduler.arn}"
+  desired_count = 2
+  iam_role = "${var.ecs_service_linked_role_arn}"
+}
+
+data "template_file" "flower" {
+  template = "${file("${path.module}/airflow.json")}"
+
+  vars {
+    account = "${var.account}"
+    container_name = "airflow-flower-${var.environment}"
+    container_port = 5555
+    fernet_key = "airflow-${var.environment}.fernet"
+    host_port = 0
+    redis_host = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.address}"
+    redis_port = "${aws_elasticache_cluster.celery_queue.cache_nodes.0.port}"
+    postgres_host = "${var.airflow_database_address}"
+    postgres_pass_key = "airflow-${var.environment}.pass"
+    postgres_user_key = "airflow-${var.environment}.user"
+    environment = "${var.environment}"
+    image = "${local.ecr_registry}/airflow:${var.environment}"
+    command = "flower"
+    region = "${var.region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "flower" {
+  family = "airflow-flower-${var.environment}"
+  container_definitions = "${data.template_file.flower.rendered}"
+  execution_role_arn = "${aws_iam_role.airflow_task_execution_role.arn}"
+}
+
+resource "aws_ecs_service" "flower" {
+  name = "airflow-flower-${var.environment}"
+  cluster = "${var.ecs_cluster_id}"
+  task_definition = "${aws_ecs_task_definition.flower.arn}"
+  desired_count = 1
+  iam_role = "${var.ecs_service_linked_role_arn}"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.flower.id}"
+    container_name = "airflow-flower-${var.environment}"
+    container_port = 5555
+  }
+}

--- a/terraform/modules/airflow/policy.tf
+++ b/terraform/modules/airflow/policy.tf
@@ -16,17 +16,17 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
   }
 }
 
-resource "aws_iam_role" "metabase_task_execution_role" {
-  name = "${var.environment}-metabase-task"
+resource "aws_iam_role" "airflow_task_execution_role" {
+  name = "${var.environment}-airflow-task"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_assume_role_policy.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "metabase_task_execution_role_policy" {
-  role = "${aws_iam_role.metabase_task_execution_role.name}"
+resource "aws_iam_role_policy_attachment" "airflow_task_execution_role_policy" {
+  role = "${aws_iam_role.airflow_task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-data "aws_iam_policy_document" "metabase_kms_policy" {
+data "aws_iam_policy_document" "airflow_kms_policy" {
   statement {
     actions = ["ssm:DescribeParameters"]
     resources = ["*"]
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "metabase_kms_policy" {
 
   statement {
     actions = ["ssm:GetParameters","ssm:GetParameter"]
-    resources = ["${format("arn:aws:ssm:%s:%s:parameter/metabase-%s.*", var.region, var.account, var.environment)}"]
+    resources = ["${format("arn:aws:ssm:%s:%s:parameter/airflow-%s.*", var.region, var.account, var.environment)}"]
     effect = "Allow"
   }
 
@@ -46,17 +46,17 @@ data "aws_iam_policy_document" "metabase_kms_policy" {
   }
 }
 
-resource "aws_iam_policy" "metabase_kms_policy" {
-  name = "${local.base_name}-metabase-kms"
-  policy = "${data.aws_iam_policy_document.metabase_kms_policy.json}"
+resource "aws_iam_policy" "airflow_kms_policy" {
+  name = "${local.base_name}-airflow-kms"
+  policy = "${data.aws_iam_policy_document.airflow_kms_policy.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "metabase_kms_policy" {
-  role = "${aws_iam_role.metabase_task_execution_role.name}"
-  policy_arn = "${aws_iam_policy.metabase_kms_policy.arn}"
+resource "aws_iam_role_policy_attachment" "airflow_kms_policy" {
+  role = "${aws_iam_role.airflow_task_execution_role.name}"
+  policy_arn = "${aws_iam_policy.airflow_kms_policy.arn}"
 }
 
-data "aws_iam_policy_document" "metabase_cloudwatch_policy" {
+data "aws_iam_policy_document" "airflow_cloudwatch_policy" {
   statement {
     actions = [
       "logs:CreateLogGroup",
@@ -80,13 +80,13 @@ data "aws_iam_policy_document" "metabase_cloudwatch_policy" {
   }
 }
 
-resource "aws_iam_policy" "metabase_task_cloudwatch" {
-  name = "${local.base_name}-metabase-task-cloudwatch"
-  policy = "${data.aws_iam_policy_document.metabase_cloudwatch_policy.json}"
+resource "aws_iam_policy" "airflow_task_cloudwatch" {
+  name = "${local.base_name}-airflow-task-cloudwatch"
+  policy = "${data.aws_iam_policy_document.airflow_cloudwatch_policy.json}"
 }
 
-resource "aws_iam_policy_attachment" "metabase_task_cloudwatch_attachment" {
-  name = "${local.base_name}-metabase-task-cloudwatch"
-  roles = ["${aws_iam_role.metabase_task_execution_role.name}"]
-  policy_arn = "${aws_iam_policy.metabase_task_cloudwatch.arn}"
+resource "aws_iam_policy_attachment" "airflow_task_cloudwatch_attachment" {
+  name = "${local.base_name}-airflow-task-cloudwatch"
+  roles = ["${aws_iam_role.airflow_task_execution_role.name}"]
+  policy_arn = "${aws_iam_policy.airflow_task_cloudwatch.arn}"
 }

--- a/terraform/modules/airflow/vars.tf
+++ b/terraform/modules/airflow/vars.tf
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 by Audere
+//
+// Use of this source code is governed by an MIT-style license that
+// can be found in the LICENSE file distributed with this file.
+
+variable "account" {
+  description = "Identifier for the AWS account"
+}
+
+variable "airflow_database_address" {
+  description = "Postgres db address for Airflow backend"
+}
+
+variable "app_subnet_id" {
+  description = "Subnet in which applications should be deployed"
+}
+
+variable "app_b_subnet_id" {
+  description = "Backup subnet in which applications should be deployed"
+}
+
+variable "auderenow_certificate_arn" {
+  description = "ARN for the certificate to associate with the Route53 record"
+}
+
+variable "auderenow_route53_zone_id" {
+  description = "Identifier for the Route53 hosted zone"
+}
+
+variable "auderenow_route53_zone_name" {
+  description = "Name for the Route53 hosted zone"
+}
+
+variable "ecs_dynamic_client_sg_id" {
+  description = "Security group to send traffic to dynamic ECS ports"
+}
+
+variable "elb_logs_bucket_id" {
+  description = "Identifier for bucket to capture ELB access logs"
+}
+
+variables "ecs_cluster_id" {
+  description = "Identifier for ECS cluster to run reporting applications"
+}
+
+variable "ecs_service_linked_role_arn" {
+  description = "ARN of the role linked to the ECS service on this account"
+}
+
+variable "environment" {
+  description = "One of 'staging' or 'prod'"
+}
+
+variable "redis_server_sg_id" {
+  description = "Security group to receive traffic on Redis server"
+}
+
+variable "region" {
+  description = "Targeted AWS region"
+}
+
+variable "vpc_id" {
+  description = "Identifier for the VPC"
+}

--- a/terraform/modules/app-shared/main.tf
+++ b/terraform/modules/app-shared/main.tf
@@ -47,9 +47,11 @@ module "ecs_cluster" {
   subnet_ids = ["${var.app_subnet_id}"]
   security_groups = [
     "${var.internet_egress_sg_id}",
-    "${var.reporting_server_sg_id}",
     "${var.db_client_sg_id}",
     "${var.dev_ssh_server_sg_id}",
+    "${var.ecs_dynamic_server_sg_id}",
+    "${var.redis_client_sg_id}",
+    "${var.reporting_server_sg_id}",
   ]
 }
 
@@ -69,6 +71,24 @@ module "cough_sftp" {
   sftp_host = "${module.sftp.sftp_host}"
   transfer_server_id = "${module.sftp.transfer_server_id}"
   user_public_key = "${file("${path.module}/../../../local/sftp-keys/cough.${var.environment}.pub")}"
+}
+
+
+// --------------------------------------------------------------------------------
+// Airflow DAGs bucket
+
+resource "aws_s3_bucket" "airflow_dags_bucket" {
+  bucket = "airflow-dags-${var.environment}"
+  acl = "private"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
 }
 
 locals {

--- a/terraform/modules/app-shared/vars.tf
+++ b/terraform/modules/app-shared/vars.tf
@@ -7,6 +7,10 @@ variable "app_subnet_id" {
   description = "Subnet in which applications should be deployed"
 }
 
+variable "build_user" {
+  description = "User that executes infrastructure tasks from the build"
+}
+
 variable "db_client_sg_id" {
   description = "Security group to open database client traffic"
 }
@@ -20,6 +24,10 @@ variable "devs" {
   type = "list"
 }
 
+variable "ecs_dynamic_server_sg_id" {
+  description = "Security group to receive traffic to dynamic ECS ports"
+}
+
 variable "environment" {
   description = "One of 'staging' or 'prod'"
 }
@@ -31,6 +39,10 @@ variable "infra_alerts_sns_topic_arn" {
 
 variable "internet_egress_sg_id" {
   description = "Security group to open internet egress"
+}
+
+variable "redis_client_sg_id" {
+  description = "Security group to send traffic to Redis server"
 }
 
 variable "reporting_server_sg_id" {

--- a/terraform/modules/ecs-cluster/cloud-init.sh
+++ b/terraform/modules/ecs-cluster/cloud-init.sh
@@ -29,6 +29,10 @@ function main() {
   yum -y update
   yum -y install tar bzip2 jq unzip wget
 
+  # Mount Airflow DAGs
+  add_s3fs
+  s3fs -o allow_other -o use_sse=1 airflow-dags-${environment} /sf3s/dags
+
   add_developer_accounts
   download_assets
 
@@ -47,6 +51,11 @@ function add_developer() {
   useradd -m -c "$u" "$u"
   write_sshkey "$u"
   echo "$u ALL=(ALL) NOPASSWD:ALL" >"/etc/sudoers.d/50-$u"
+}
+
+function add_s3fs() {
+  sudo amazon-linux-extras install epel
+  sudo yum install s3fs-fuse
 }
 
 function write_sshkey() {

--- a/terraform/modules/ecs-cluster/outputs.tf
+++ b/terraform/modules/ecs-cluster/outputs.tf
@@ -3,6 +3,10 @@
 // Use of this source code is governed by an MIT-style license that
 // can be found in the LICENSE file distributed with this file.
 
+output "arn" {
+  value = "${aws_ecs_cluster.cluster.arn}"
+}
+
 output "id" {
   value = "${aws_ecs_cluster.cluster.id}"
 }

--- a/terraform/modules/flu-db/main.tf
+++ b/terraform/modules/flu-db/main.tf
@@ -135,6 +135,35 @@ resource "aws_db_instance" "metabase" {
   }
 }
 
+resource "aws_db_instance" "airflow" {
+  allocated_storage = 20
+  availability_zone = "${var.availability_zone}"
+  backup_retention_period = 5
+  backup_window = "10:00-10:59"
+  copy_tags_to_snapshot = true
+  deletion_protection = true
+  engine = "postgres"
+  engine_version = "10.6"
+  identifier = "${local.base_name}-airflow"
+  instance_class = "db.t2.small"
+  license_model = "postgresql-license"
+  maintenance_window = "Sun:11:00-Sun:11:59"
+  name = "airflow"
+  password = "${local.db_setup_password}"
+  publicly_accessible = false
+  skip_final_snapshot = false
+  storage_encrypted = true
+  db_subnet_group_name = "${aws_db_subnet_group.fludb.name}"
+  username = "airflowa"
+  vpc_security_group_ids = [
+    "${var.db_server_sg_id}",
+  ]
+
+  tags {
+    Name = "${local.base_name}-airflow"
+  }
+}
+
 resource "aws_db_parameter_group" "fludb_parameters" {
   name = "${local.base_name}-parameters"
   family = "postgres10"

--- a/terraform/modules/flu-db/outputs.tf
+++ b/terraform/modules/flu-db/outputs.tf
@@ -7,6 +7,10 @@ output "api_creds_snapshot_id" {
   value = "${element(concat(aws_ebs_snapshot.api_creds.*.id, list("StillProvisioningNoSnapshotYet")), 0)}"
 }
 
+output "airflow_database_address" {
+  value = "${aws_db_instance.airflow.address}"
+}
+
 output "metabase_database_address" {
   value = "${aws_db_instance.metabase.address}"
 }

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -7,6 +7,10 @@ output "app_subnet_id" {
   value = "${aws_subnet.app.id}"
 }
 
+output "app_b_subnet_id" {
+  value = "${aws_subnet.app_b.id}"
+}
+
 output "bastion_ingress_sg_id" {
   value = "${aws_security_group.bastion_ingress.id}"
 }
@@ -51,6 +55,14 @@ output "db_pii_subnet_id" {
   value = "${aws_subnet.db_pii.id}"
 }
 
+output "ecs_dynamic_client_sg_id" {
+  value = "${aws_security_group.ecs_dynamic_ports_sg.client_id}"
+}
+
+output "ecs_dynamic_server_sg_id" {
+  value = "${aws_security_group.ecs_dynamic_ports_sg.server_id}"
+}
+
 output "fluapi_client_sg_id" {
   value = "${module.fluapi_sg.client_id}"
 }
@@ -77,6 +89,14 @@ output "internet_egress_sg_id" {
 
 output "public_http_sg_id" {
   value = "${aws_security_group.public_http.id}"
+}
+
+output "redis_client_sg_id" {
+  value = "${module.redis_sg.client_id}"
+}
+
+output "redis_server_sg_id" {
+  value = "${module.redis_sg.server_id}"
 }
 
 output "reporting_client_sg_id" {

--- a/terraform/modules/network/vars.tf
+++ b/terraform/modules/network/vars.tf
@@ -14,6 +14,12 @@ variable "availability_zone" {
   default = "us-west-2a"
 }
 
+variable "secondary_availability_zone" {
+  description = "Secondary/backup availability zone for high-availability"
+  type = "string"
+  default = "us-west-2b"
+}
+
 variable "bastion_cidr_whitelist" {
   description = "CIDR blocks for source IPs allowed to connect to bastion server."
   type = "list"

--- a/terraform/modules/reporting/main.tf
+++ b/terraform/modules/reporting/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 // --------------------------------------------------------------------------------
-// ELB/domain setup
+// Reporting public ELB/domain setup
 
 resource "aws_route53_record" "reporting_record" {
   zone_id = "${var.auderenow_route53_zone_id}"
@@ -85,7 +85,7 @@ data "template_file" "metabase" {
 resource "aws_ecs_task_definition" "metabase" {
   family = "metabase-${var.environment}"
   container_definitions = "${data.template_file.metabase.rendered}"
-  execution_role_arn = "${aws_iam_role.ecs_task_execution_role.arn}"
+  execution_role_arn = "${aws_iam_role.metabase_task_execution_role.arn}"
 }
 
 resource "aws_ecs_service" "metabase" {

--- a/terraform/prod/1-network/outputs.tf
+++ b/terraform/prod/1-network/outputs.tf
@@ -51,6 +51,14 @@ output "dev_machine_subnet_id" {
   value = "${module.env_network.dev_machine_subnet_id}"
 }
 
+output "ecs_dynamic_client_sg_id" {
+  value = "${module.env_network.ecs_dynamic_client_sg_id}"
+}
+
+output "ecs_dynamic_server_sg_id" {
+  value = "${module.env_network.ecs_dynamic_server_sg_id}"
+}
+
 output "fluapi_internal_client_sg_id" {
   value = "${module.env_network.fluapi_internal_client_sg_id}"
 }
@@ -77,6 +85,14 @@ output "internet_egress_sg_id" {
 
 output "public_http_sg_id" {
   value = "${module.env_network.public_http_sg_id}"
+}
+
+output "redis_client_sg_id" {
+  value = "${module.env_network.redis_client_sg_id}"
+}
+
+output "redis_server_sg_id" {
+  value = "${module.env_network.redis_server_sg_id}"
 }
 
 output "reporting_client_sg_id" {

--- a/terraform/prod/4-db/outputs.tf
+++ b/terraform/prod/4-db/outputs.tf
@@ -7,6 +7,10 @@ output "api_creds_snapshot_id" {
   value = "${module.flu_db.api_creds_snapshot_id}"
 }
 
+output "airflow_database_address" {
+  value = "${module.flu_db.airflow_database_address}"
+}
+
 output "metabase_database_address" {
   value = "${module.flu_db.metabase_database_address}"
 }

--- a/terraform/prod/5-app/main.tf
+++ b/terraform/prod/5-app/main.tf
@@ -27,9 +27,11 @@ module "shared" {
   db_client_sg_id = "${data.terraform_remote_state.network.db_client_sg_id}"
   dev_ssh_server_sg_id = "${data.terraform_remote_state.network.dev_ssh_server_sg_id}"
   devs = "${var.devs}"
+  ecs_dynamic_client_sg_id = "${data.terraform_remote_state.network.ecs_dynamic_client_sg_id}"
   environment = "prod"
   infra_alerts_sns_topic_arn = "${data.terraform_remote_state.flu_notifier.infra_alerts_sns_topic_arn}"
   internet_egress_sg_id = "${data.terraform_remote_state.network.internet_egress_sg_id}"
+  redis_client_sg_id = "${data.terraform_remote_state.network.redis_client_sg_id}"
   reporting_server_sg_id = "${data.terraform_remote_state.network.reporting_server_sg_id}"
 }
 
@@ -58,6 +60,26 @@ module "flu_api" {
   public_http_sg_id = "${data.terraform_remote_state.network.public_http_sg_id}"
   service = "${var.service}"
   transient_subnet_id = "${data.terraform_remote_state.network.transient_subnet_id}"
+}
+
+module "airflow" {
+  source = "../../modules/airflow"
+
+  account = "${var.account}"
+  airflow_database_address = "${data.terraform_remote_state.flu_db.airflow_database_address}"
+  app_subnet_id = "${data.terraform_remote_state.network.app_subnet_id}"
+  app_b_subnet_id = "${data.terraform_remote_state.network.app_b_subnet_id}"
+  auderenow_certificate_arn = "${module.shared.auderenow_certificate_arn}"
+  auderenow_route53_zone_id = "${module.shared.auderenow_route53_zone_id}"
+  auderenow_route53_zone_name = "${module.shared.auderenow_route53_zone_name}"
+  ecs_cluster_id = "${module.shared.ecs_cluster_id}"
+  ecs_dynamic_client_sg_id = "${data.terraform_remote_state.network.ecs_dynamic_client_sg_id}"
+  ecs_service_linked_role_arn = "${data.terraform_remote_state.global.ecs_service_linked_role_arn}"
+  elb_logs_bucket_id = "${module.shared.elb_logs_bucket_id}"
+  environment = "prod"
+  redis_server_sg_id = "${data.terraform_remote_state.network.redis_server_sg_id}"
+  region = "${var.region}"
+  vpc_id = "${data.terraform_remote_state.network.vpc_id}"
 }
 
 module "reporting" {

--- a/terraform/staging/1-network/outputs.tf
+++ b/terraform/staging/1-network/outputs.tf
@@ -51,6 +51,14 @@ output "dev_machine_subnet_id" {
   value = "${module.env_network.dev_machine_subnet_id}"
 }
 
+output "ecs_dynamic_client_sg_id" {
+  value = "${module.env_network.ecs_dynamic_client_sg_id}"
+}
+
+output "ecs_dynamic_server_sg_id" {
+  value = "${module.env_network.ecs_dynamic_server_sg_id}"
+}
+
 output "fluapi_internal_client_sg_id" {
   value = "${module.env_network.fluapi_internal_client_sg_id}"
 }

--- a/terraform/staging/4-db/outputs.tf
+++ b/terraform/staging/4-db/outputs.tf
@@ -7,6 +7,10 @@ output "api_creds_snapshot_id" {
   value = "${module.flu_db.api_creds_snapshot_id}"
 }
 
+output "airflow_database_address" {
+  value = "${module.flu_db.airflow_database_address}"
+}
+
 output "metabase_database_address" {
   value = "${module.flu_db.metabase_database_address}"
 }

--- a/terraform/staging/5-app/main.tf
+++ b/terraform/staging/5-app/main.tf
@@ -27,9 +27,11 @@ module "shared" {
   db_client_sg_id = "${data.terraform_remote_state.network.db_client_sg_id}"
   dev_ssh_server_sg_id = "${data.terraform_remote_state.network.dev_ssh_server_sg_id}"
   devs = "${var.devs}"
+  ecs_dynamic_client_sg_id = "${data.terraform_remote_state.network.ecs_dynamic_client_sg_id}"
   environment = "staging"
   infra_alerts_sns_topic_arn = "${data.terraform_remote_state.flu_notifier.infra_alerts_sns_topic_arn}"
   internet_egress_sg_id = "${data.terraform_remote_state.network.internet_egress_sg_id}"
+  redis_client_sg_id = "${data.terraform_remote_state.network.redis_client_sg_id}"
   reporting_server_sg_id = "${data.terraform_remote_state.network.reporting_server_sg_id}"
 }
 
@@ -58,6 +60,26 @@ module "flu_api" {
   public_http_sg_id = "${data.terraform_remote_state.network.public_http_sg_id}"
   service = "${var.service}"
   transient_subnet_id = "${data.terraform_remote_state.network.transient_subnet_id}"
+}
+
+module "airflow" {
+  source = "../../modules/airflow"
+
+  account = "${var.account}"
+  airflow_database_address = "${data.terraform_remote_state.flu_db.airflow_database_address}"
+  app_subnet_id = "${data.terraform_remote_state.network.app_subnet_id}"
+  app_b_subnet_id = "${data.terraform_remote_state.network.app_b_subnet_id}"
+  auderenow_certificate_arn = "${module.shared.auderenow_certificate_arn}"
+  auderenow_route53_zone_id = "${module.shared.auderenow_route53_zone_id}"
+  auderenow_route53_zone_name = "${module.shared.auderenow_route53_zone_name}"
+  ecs_cluster_id = "${module.shared.ecs_cluster_id}"
+  ecs_dynamic_client_sg_id = "${data.terraform_remote_state.network.ecs_dynamic_client_sg_id}"
+  ecs_service_linked_role_arn = "${data.terraform_remote_state.global.ecs_service_linked_role_arn}"
+  elb_logs_bucket_id = "${module.shared.elb_logs_bucket_id}"
+  environment = "prod"
+  redis_server_sg_id = "${data.terraform_remote_state.network.redis_server_sg_id}"
+  region = "${var.region}"
+  vpc_id = "${data.terraform_remote_state.network.vpc_id}"
 }
 
 module "reporting" {


### PR DESCRIPTION
Sketching out Airflow task definitions and a basic container deployment workflow.  This ended up being more involved and a larger set of changes than I desired.  I don't find it urgent to get this merged/functional and would be happy to pivot or take and feedback on the approach.

Takeaways/proposed changes:

- Task definitions for ECS are defined in Terraform and affix to a well-known tag (e.g. staging or prod)
- CircleCI is used for deployments & creating/tagging new images
  - Initially CircleCI is used to build the container image and push to ECR with a staging tag - after tagging the image is deployed to the staging ECS cluster
  - The current staging tag can be promoted prod - this is done by forcing a redeploy of the prod task after the prod tag is added to the image
  - For Airflow specifically there is a workflow to sync a folder to an S3 bucket for DAGs
  - CircleCI uses orbs (their plug-in system) to simplify some of the AWS access & is updated from version 2 to 2.1 of their spec as a result
  - The build workflows are conditionally triggered using [pipeline parameters](https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/conditional-workflows.md) which is part of their publicly available preview release of their next major API version
- The aforementioned CircleCI workflows are not part of CI so we don't pull an array of base images on unrelated changes, instead they are triggered manually via scripts that access the preview release API
  - API access requires creation of a CircleCI token at the user level which is then referenced via an environment variable
- The scripts for invoking CircleCI builds reference a JSON registry for task definitions where new services must be defined - this collects information for scripts/CircleCI that otherwise lives in Terraform
- Task definitions for Airflow have been added using Celery for execution and scheduling through Postgres and Redis
  - s3fs-fuse is installed on ECS hosts to mount the DAGs S3 bucket, the task definitions then reference this as a volume that is mounted locally
  - An Application Load Balancer fronts both the Airflow webserver and Celery UI to enable dynamic port mappings & as a result a dummy subnet has been created in a secondary availability zone (the ALB must reside in > 1 AZ)
  - Dynamic port mappings are used instead of awsvpc networking since the ECS host has a limit of 3 total network interfaces - this also means that tasks do not express ingress/egress rules and permissions & they are still aggregated by the host

Everything is untested at the moment, so there are probably some misunderstandings, syntax errors, and lapses of basic logic.  There are also a few things that are not yet done - notably Airflow interactions happen almost entirely through the database but log collection directly queries worker nodes.  With dynamic port mappings we'd have to do some sleight of hand to get the correct configuration.  Instead I was planning to configure remote logging to S3 so that log collection didn't need to reference workers directly.