### PR TITLE
Add form for setting "expert read" data on cough photos

### DIFF
--- a/FluApi/db/migrations/nonpii/20190829183322-add-cough-expert-read.js
+++ b/FluApi/db/migrations/nonpii/20190829183322-add-cough-expert-read.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 by Audere
+//
+// Use of this source code is governed by an MIT-style license that
+// can be found in the LICENSE file distributed with this file.
+
+'use strict';
+
+const { baseColumns, column, foreignIdKey } = require("../../util");
+const schema = "cough";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable(
+      "expert_read",
+      {
+        ...baseColumns(Sequelize),
+        surveyId: foreignIdKey(Sequelize, {
+          tableName: "current_surveys",
+          schema: "cough"
+        }),
+        interpretation: column(Sequelize.STRING),
+        interpreterId: column(Sequelize.INTEGER),
+      },
+      { schema }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable({ tableName: "expert_read", schema });
+  }
+};

--- a/FluApi/src/endpoints/webPortal/auth.ts
+++ b/FluApi/src/endpoints/webPortal/auth.ts
@@ -176,6 +176,8 @@ function makeToken({ salt, userid, password }: TokenParts): string {
 export const Permissions = {
   SEATTLE_CHILDRENS_HIPAA_ACCESS: "seattleChildrensHipaaAccess",
   COUGH_RDT_PHOTOS_ACCESS: "coughRdtPhotosAccess",
+  COUGH_RDT_PHOTOS_WRITE: "coughRdtPhotosWrite",
+  COUGH_RDT_PHOTOS_INTERPRETATION_WRITE: "coughRdtPhotosInterpretationWrite",
 };
 
 export function authorizationMiddleware(

--- a/FluApi/src/endpoints/webPortal/auth.ts
+++ b/FluApi/src/endpoints/webPortal/auth.ts
@@ -176,7 +176,7 @@ function makeToken({ salt, userid, password }: TokenParts): string {
 export const Permissions = {
   SEATTLE_CHILDRENS_HIPAA_ACCESS: "seattleChildrensHipaaAccess",
   COUGH_RDT_PHOTOS_ACCESS: "coughRdtPhotosAccess",
-  COUGH_RDT_PHOTOS_INTERPRETATION_WRITE: "coughRdtPhotosInterpretationWrite",
+  COUGH_INTERPRETATION_WRITE: "coughInterpretationWrite",
 };
 
 export function authorizationMiddleware(

--- a/FluApi/src/endpoints/webPortal/auth.ts
+++ b/FluApi/src/endpoints/webPortal/auth.ts
@@ -176,7 +176,6 @@ function makeToken({ salt, userid, password }: TokenParts): string {
 export const Permissions = {
   SEATTLE_CHILDRENS_HIPAA_ACCESS: "seattleChildrensHipaaAccess",
   COUGH_RDT_PHOTOS_ACCESS: "coughRdtPhotosAccess",
-  COUGH_RDT_PHOTOS_WRITE: "coughRdtPhotosWrite",
   COUGH_RDT_PHOTOS_INTERPRETATION_WRITE: "coughRdtPhotosInterpretationWrite",
 };
 

--- a/FluApi/src/endpoints/webPortal/endpoint.ts
+++ b/FluApi/src/endpoints/webPortal/endpoint.ts
@@ -188,6 +188,14 @@ function addHandlers(
     authorizationMiddleware(authManager, Permissions.COUGH_RDT_PHOTOS_ACCESS),
     wrap(rdtPhotosServer.showPhotos)
   );
+  app.post(
+    "/setExpertRead",
+    authorizationMiddleware(
+      authManager,
+      Permissions.COUGH_RDT_PHOTOS_INTERPRETATION_WRITE
+    ),
+    wrap(rdtPhotosServer.setExpertRead)
+  );
 
   const manageAccount = new ManageAccount(config.sql, getStatic);
   app.get("/manageAccount", wrap(manageAccount.getForm));

--- a/FluApi/src/endpoints/webPortal/endpoint.ts
+++ b/FluApi/src/endpoints/webPortal/endpoint.ts
@@ -192,7 +192,7 @@ function addHandlers(
     "/setExpertRead",
     authorizationMiddleware(
       authManager,
-      Permissions.COUGH_RDT_PHOTOS_INTERPRETATION_WRITE
+      Permissions.COUGH_INTERPRETATION_WRITE
     ),
     wrap(rdtPhotosServer.setExpertRead)
   );

--- a/FluApi/src/endpoints/webPortal/endpoint.ts
+++ b/FluApi/src/endpoints/webPortal/endpoint.ts
@@ -177,7 +177,7 @@ function addHandlers(
     wrap(s3DirectoryServer.performRequest)
   );
 
-  const rdtPhotosServer = new RDTPhotos(config.sql, getStatic);
+  const rdtPhotosServer = new RDTPhotos(config.sql, getStatic, authManager);
   app.get(
     "/coughPhotos",
     authorizationMiddleware(authManager, Permissions.COUGH_RDT_PHOTOS_ACCESS),

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -7,6 +7,7 @@ import { Op, cast, json, where, col, fn } from "sequelize";
 import querystring from "querystring";
 import { SplitSql } from "../../util/sql";
 import { CoughModels, defineCoughModels } from "../../models/db/cough";
+import { AuthManager, Permissions } from "./auth";
 
 const LABELS = {
   RDTReaderPhotoGUID: "Automatic Capture",
@@ -23,14 +24,29 @@ const ORDER_OPTIONS = {
 
 const PAGE_SIZE = 50;
 
+const INTERPRETATIONS = {
+  badPicture: "Unusable Photo",
+  noBlue: "Invalid Result (no blue line)",
+  noPink: "No pink line",
+  yesAboveBlue: "Pink line above the blue line",
+  yesBelowBlue: "Pink line below the blue line",
+  yesAboveBelowBlue: "Pink lines above and below the blue line",
+};
+
 export class RDTPhotos {
-  constructor(sql: SplitSql, getStatic: () => string) {
+  constructor(
+    sql: SplitSql,
+    getStatic: () => string,
+    authManager: AuthManager
+  ) {
     this.models = defineCoughModels(sql);
     this.getStatic = getStatic;
+    this.authManager = authManager;
   }
 
   private models: CoughModels;
   private getStatic: () => string;
+  private authManager: AuthManager;
 
   public listBarcodes = async (req, res) => {
     const page =
@@ -138,6 +154,26 @@ export class RDTPhotos {
         })
     );
 
-    res.render("rdtPhotos.html", { photos, static: this.getStatic() });
+    const canInterpret = this.authManager.authorize(
+      req.user.userid,
+      Permissions.COUGH_RDT_PHOTOS_INTERPRETATION_WRITE
+    );
+    const expertRead = await this.models.expertRead.findOne({
+      where: { surveyId: id },
+    });
+    const oldInterpretation = expertRead && expertRead.interpretation;
+    const interpretations = Object.keys(INTERPRETATIONS).map(
+      interpretation => ({
+        value: interpretation,
+        label: INTERPRETATIONS[interpretation],
+        checked: oldInterpretation === interpretation ? "checked" : "",
+      })
+    );
+    res.render("rdtPhotos.html", {
+      photos,
+      static: this.getStatic(),
+      canInterpret,
+      interpretations,
+    });
   };
 }

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -156,7 +156,7 @@ export class RDTPhotos {
 
     const canInterpret = this.authManager.authorize(
       req.user.userid,
-      Permissions.COUGH_RDT_PHOTOS_INTERPRETATION_WRITE
+      Permissions.COUGH_INTERPRETATION_WRITE
     );
     const expertRead = await this.models.expertRead.findOne({
       where: { surveyId: id },

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -172,8 +172,21 @@ export class RDTPhotos {
     res.render("rdtPhotos.html", {
       photos,
       static: this.getStatic(),
+      surveyId: id,
+      csrf: req.csrfToken(),
       canInterpret,
       interpretations,
     });
+  };
+
+  public setExpertRead = async (req, res) => {
+    const { surveyId, interpretation } = req.body;
+    const interpreterId = req.user.id;
+    await this.models.expertRead.upsert({
+      surveyId,
+      interpretation,
+      interpreterId,
+    });
+    res.redirect(303, `./coughPhoto?id=${surveyId}`);
   };
 }

--- a/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
+++ b/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
@@ -24,6 +24,18 @@ can be found in the LICENSE file distributed with this file.
         <h3>{{label}}</h3>
         <img src={{src}}>
       {{/each}}
-    </ul>
+      {{#if canInterpret}}
+        <form action="./setExpertRead" method="post">
+          {{#each interpretations}}
+            <div>
+              <input type="radio" id="{{value}}" name="interpretation" value="{{value}}" {{checked}} />
+              <label for="{{value}}">{{label}}</label>
+            </div>
+          {{/each}}
+          <div>
+            <input type="submit" value="Save"/>
+          </div>
+        </form>
+      {{/if}}
   </body>
 </html>

--- a/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
+++ b/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
@@ -26,6 +26,8 @@ can be found in the LICENSE file distributed with this file.
       {{/each}}
       {{#if canInterpret}}
         <form action="./setExpertRead" method="post">
+          <input type="hidden" name="_csrf" value="{{csrf}}"/>
+          <input type="hidden" name="surveyId" value="{{surveyId}}"/>
           {{#each interpretations}}
             <div>
               <input type="radio" id="{{value}}" name="interpretation" value="{{value}}" {{checked}} />

--- a/FluApi/src/models/db/cough.ts
+++ b/FluApi/src/models/db/cough.ts
@@ -32,6 +32,7 @@ export function defineCoughModels(sql: SplitSql): CoughModels {
     accessKey: defineAccessKey(sql),
     asprenData: defineAsprenData(sql),
     asprenFile: defineAsprenFile(sql),
+    expertRead: defineExpertRead(sql),
     firebaseAnalytics: defineFirebaseAnalytics(sql),
     firebaseAnalyticsTable: defineFirebaseAnalayticsTable(sql),
     importProblem: defineImportProblem(sql),
@@ -52,6 +53,7 @@ export interface CoughModels {
   accessKey: Model<AccessKeyAttributes>;
   asprenData: Model<AsprenDataAttributes>;
   asprenFile: Model<AsprenFileAttributes>;
+  expertRead: Model<ExpertReadAttributes>;
   firebaseAnalytics: Model<FirebaseAnalyticsAttributes>;
   firebaseAnalyticsTable: Model<FirebaseAnalyticsTableAttributes>;
   importProblem: Model<ImportProblemAttributes>;
@@ -339,6 +341,27 @@ export function defineFirebaseAnalayticsTable(
     {
       name: unique(stringColumn()),
       modified: bigIntColumn(),
+    },
+    { schema }
+  );
+}
+
+// ---------------------------------------------------------------
+
+export interface ExpertReadAttributes {
+  surveyId: number;
+  interpretation: string;
+  interpreterId: number;
+}
+
+export function defineExpertRead(sql: SplitSql): Model<ExpertReadAttributes> {
+  return defineModel<ExpertReadAttributes>(
+    sql.nonPii,
+    "expert_read",
+    {
+      surveyId: unique(integerColumn("surveyId")),
+      interpretation: stringColumn("interpretation"),
+      interpreterId: integerColumn("interpreterId"),
     },
     { schema }
   );

--- a/FluApi/src/services/dataPipelineService.ts
+++ b/FluApi/src/services/dataPipelineService.ts
@@ -253,7 +253,9 @@ function getNonPiiDataNodes(): ManagedSqlNode[] {
       name: "cough_derived.non_demo_surveys",
       deps: [],
       spec: `
-        select * from cough.current_surveys
+        select cough.current_surveys.*, cough.expert_read.interpretation as expert_interpretation from
+          cough.current_surveys
+          left join cough.expert_read on cough.current_surveys.id = cough.expert_read."surveyId"
         where survey->>'isDemo' = 'false'
       `,
     }),
@@ -270,7 +272,8 @@ function getNonPiiDataNodes(): ManagedSqlNode[] {
           device,
           survey,
           ${namedResponseColumns(SURVEY_QUESTIONS).join(",\n  ")},
-          ${namedSampleColumns().join(",\n  ")}
+          ${namedSampleColumns().join(",\n  ")},
+          expert_interpretation
         from cough_derived.non_demo_surveys
       `,
     }),
@@ -337,7 +340,8 @@ function getNonPiiDataNodes(): ManagedSqlNode[] {
           survey->'rdtInfo'->'rdtReaderResult'->>'controlLineFound' as rdtreaderresult_controllinefound,
           survey->'rdtInfo'->'rdtReaderResult'->>'testALineFound' as rdtreaderresult_testalinefound,
           survey->'rdtInfo'->'rdtReaderResult'->>'testBLineFound' as rdtreaderresult_testblinefound,
-          survey->'rdtInfo'->'rdtReaderResult'->>'testStripBoundary' as rdtreaderresult_teststripboundary
+          survey->'rdtInfo'->'rdtReaderResult'->>'testStripBoundary' as rdtreaderresult_teststripboundary,
+          expert_interpretation
         from cough_derived.survey_named_array_items
       `,
     }),


### PR DESCRIPTION
Show a form alongside cough photos for Sam (or whoever else has permission) to enter their interpretation of a test strip. This data will be used by us and/or Ubicomp to assess the accuracy of automatic interpretation.

![image](https://user-images.githubusercontent.com/1070243/63975020-e212cf00-ca62-11e9-97f0-157441f2b7ae.png)
