### PR TITLE
FEV-1049 Fix native callback property name

### DIFF
--- a/FluStudy_au/src/native/rdtReader.tsx
+++ b/FluStudy_au/src/native/rdtReader.tsx
@@ -11,7 +11,7 @@ type InternalRDTCapturedArgs = {
   img: string;
   resultWindowImg: string;
   passed: boolean;
-  testStripFound: boolean;
+  testStripDetected: boolean;
   center: boolean;
   fiducial: boolean;
   sizeResult: RDTReaderSizeResult;
@@ -71,7 +71,7 @@ export class RDTReader extends React.Component<RDTReaderProps> {
       imgBase64: capturedArgs.img,
       resultWindowImgBase64: capturedArgs.resultWindowImg,
       testStripFound: capturedArgs.passed,
-      testStripDetected: capturedArgs.testStripFound,
+      testStripDetected: capturedArgs.testStripDetected,
       isCentered: capturedArgs.center,
       fiducialFound: capturedArgs.fiducial,
       sizeResult: capturedArgs.sizeResult,


### PR DESCRIPTION
This property is called `testStripDetected` in native code, not `testStripFound`:
https://github.com/AudereNow/audere/blob/0fe31f018f4071f8f30e6502379b74e4d8c72120/FluStudy_au/ios/fluathome/RDTView.mm#L65
https://github.com/AudereNow/audere/blob/0fe31f018f4071f8f30e6502379b74e4d8c72120/FluStudy_au/android/app/src/main/java/host/exp/exponent/RDTReader.java#L111

I was trying to use this property to automatically turn off the flash when the test strip is detected yet the picture is overexposed, but @smeds1 found that it wasn't working.