### PR TITLE
FEV-1176 Reduce RDT processing resolution on memory warning

### DIFF
--- a/FluStudy_au/ios/fluathome/RDTReader/ImageProcessor.h
+++ b/FluStudy_au/ios/fluathome/RDTReader/ImageProcessor.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, SizeResult ) {
 };
 
 + (ImageProcessor *)sharedProcessor;
+@property (nonatomic) double frameImageScale;
 typedef void (^ImageProcessorBlock)(bool passed, bool testStripDetected, UIImage *img, UIImage *croppedRDTImg, bool fiducial, ExposureResult exposureResult, SizeResult sizeResult, bool center, bool orientation, float angle, bool sharpness, bool shadow, std::vector<Point2f> boundary);//, Mat resultWindowMat); // Return hashmap features to client
 - (void)captureRDT:(CMSampleBufferRef)sampleBuffer withCompletion:(ImageProcessorBlock)completion;
 - (NSString *) getInstruction: (SizeResult) sizeResult andFor: (bool) isCentered andFor: (bool) isRightOrientation;
@@ -39,7 +40,7 @@ typedef void (^ImageProcessorBlock)(bool passed, bool testStripDetected, UIImage
 - (void) toggleFlash: (AVCaptureDevice *) device with: (dispatch_queue_t) sessionQueue;
 - (CALayer *) generateViewFinder: (UIView *) view forPreview: (UIView *) previewView;
 - (UIImage *) interpretResultFromImage:(UIImage*) img andControlLine: (bool*) control andTestA: (bool*) testA andTestB: (bool*) testB;
--(UIImage *) interpretResultWithBoundaryFromImage:(UIImage*) img withBoundary:(std::vector<Point2f>) boundary andControlLine: (bool*) control andTestA: (bool*) testA andTestB: (bool*) testB;
+- (UIImage *) interpretResultWithBoundaryFromImage:(UIImage*) img withBoundary:(std::vector<Point2f>) boundary andControlLine: (bool*) control andTestA: (bool*) testA andTestB: (bool*) testB;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FluStudy_au/ios/fluathome/RDTReader/ImageProcessor.mm
+++ b/FluStudy_au/ios/fluathome/RDTReader/ImageProcessor.mm
@@ -64,7 +64,7 @@ const int RESULT_WINDOW_WIDTH = 200;
 const int RESULT_WINDOW_HEIGHT = 30;
 const double ENHANCING_THRESHOLD = 4.5;
 const BOOL DEBUG_FLAG = NO;
-const double FRAME_IMAGE_SCALE = 1.0;
+const double DEFAULT_FRAME_IMAGE_SCALE = 1.0;
 
 NSString *instruction_detected = @"RDT detected at the center!";
 NSString *instruction_pos = @"Place RDT at the center.\nFit RDT to the rectangle.";
@@ -93,6 +93,7 @@ Mat siftRefDescriptor;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedWrapper = [[self alloc] init];
+        sharedWrapper.frameImageScale = DEFAULT_FRAME_IMAGE_SCALE;
         detector = BRISK::create(45, 4, 1.0f);
         matcher = BFMatcher::create(cv::NORM_HAMMING); // 4 indicates BF Hamming
         
@@ -1097,7 +1098,7 @@ Mat siftRefDescriptor;
     double avgDist = 0.0;
     
     Mat scaledMat = Mat();
-    cv::resize(inputMat, scaledMat, cv::Size(), FRAME_IMAGE_SCALE, FRAME_IMAGE_SCALE, INTER_LINEAR);
+    cv::resize(inputMat, scaledMat, cv::Size(), self.frameImageScale, self.frameImageScale, INTER_LINEAR);
     
     Mat mask = Mat(scaledMat.size().width, scaledMat.size().height, CV_8U, Scalar(0));
     
@@ -1205,9 +1206,9 @@ Mat siftRefDescriptor;
             
             for (int i = 0; i < 4; i++) {
                 if(rotatedRect.angle < -45)
-                    boundary[(i+2)%4] = cv::Point(v[i].x/FRAME_IMAGE_SCALE, v[i].y/FRAME_IMAGE_SCALE);
+                    boundary[(i+2)%4] = cv::Point(v[i].x/self.frameImageScale, v[i].y/self.frameImageScale);
                 else
-                    boundary[(i+3)%4] = cv::Point(v[i].x/FRAME_IMAGE_SCALE, v[i].y/FRAME_IMAGE_SCALE);
+                    boundary[(i+3)%4] = cv::Point(v[i].x/self.frameImageScale, v[i].y/self.frameImageScale);
             }
             
             cv::Rect rect = boundingRect(boundary);

--- a/FluStudy_au/ios/fluathome/RDTView.mm
+++ b/FluStudy_au/ios/fluathome/RDTView.mm
@@ -118,4 +118,9 @@
     }
 }
 
+- (void) setFrameImageScale:(double) frameImageScale
+{
+    [[ImageProcessor sharedProcessor] setFrameImageScale: frameImageScale];
+}
+
 @end

--- a/FluStudy_au/ios/fluathome/RDTViewManager.mm
+++ b/FluStudy_au/ios/fluathome/RDTViewManager.mm
@@ -16,6 +16,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRDTCameraReady, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(showDefaultViewfinder, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(flashEnabled, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(frameImageScale, double);
 
 - (UIView *) view
 {

--- a/FluStudy_au/src/native/rdtReader.tsx
+++ b/FluStudy_au/src/native/rdtReader.tsx
@@ -60,6 +60,7 @@ type RDTReaderProps = {
   enabled: boolean;
   flashEnabled: boolean;
   showDefaultViewfinder?: boolean;
+  frameImageScale: number;
   appState: string;
   style: any;
 };

--- a/FluStudy_au/src/ui/components/flu/RDTReader.tsx
+++ b/FluStudy_au/src/ui/components/flu/RDTReader.tsx
@@ -113,6 +113,7 @@ class RDTReader extends React.Component<Props & WithNamespaces> {
     instructionIsOK: false,
     appState: "",
     supportsTorchMode: false,
+    frameImageScale: 1,
   };
 
   _didFocus: any;
@@ -370,6 +371,11 @@ class RDTReader extends React.Component<Props & WithNamespaces> {
 
   _handleMemoryWarning = () => {
     logFirebaseEvent(AppHealthEvents.LOW_MEMORY_WARNING);
+    if (this.state.frameImageScale === 1) {
+      this.setState({ frameImageScale: 0.5 });
+      logFirebaseEvent(AppHealthEvents.REDUCED_FRAME_SCALE);
+      return;
+    }
     if (!getRemoteConfig("advanceRDTCaptureOnMemoryWarning")) {
       return;
     }
@@ -725,6 +731,7 @@ class RDTReader extends React.Component<Props & WithNamespaces> {
           enabled={isFocused}
           showDefaultViewfinder={false}
           flashEnabled={this.state.flashEnabled}
+          frameImageScale={this.state.frameImageScale}
           appState={this.state.appState}
         />
         <View style={styles.overlayContainer}>

--- a/FluStudy_au/src/util/tracker.ts
+++ b/FluStudy_au/src/util/tracker.ts
@@ -71,6 +71,7 @@ export const TransportEvents = {
 export const AppHealthEvents = {
   CAMERA_ERROR: "camera_loading_error",
   LOW_MEMORY_WARNING: "low_memory_warning",
+  REDUCED_FRAME_SCALE: "reduced_frame_scale",
   PHOTO_UPLOADER_ERROR: "photo_uploader_error",
   REMOTE_CONFIG_ERROR: "remote_config_error",
   REMOTE_CONFIG_LOADED: "remote_config_loaded",


### PR DESCRIPTION
The first time we get a memory warning on iOS, set the `frameImageScale` to 0.5. If we get another warning, go back to the old behavior (i.e. either ignore it or skip to manual capture, depending on the remote config).

This only affects iOS, since we don't get memory warnings on Android, and Android runs at the lower resolution by default anyway.

I verified that iOS capture still seems to work at the lower resolution, though perhaps a bit slower. I wasn't able to trigger the memory warning to test that, but I did check that changing the scale in the middle of a capture session still allowed for successful captures, and reduced memory usage by ~25MB.