### PR TITLE
FEV-608 Fix sniffles build hanging at expo build:ios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
             expo login -u "$EXPO_USERNAME" -p "$EXPO_PASSWORD"
             export IOS_BUILD_NUM=`cat app.json | python -c "import sys, json; print(json.load(sys.stdin)['expo']['ios']['buildNumber'])"`
             echo "About to build iOS binary $IOS_BUILD_NUM for $EXPO_RELEASE_CHANNEL"
-            expo build:ios --non-interactive --release-channel "$EXPO_RELEASE_CHANNEL"
+            expo build:ios --no-publish --non-interactive --release-channel "$EXPO_RELEASE_CHANNEL"
             export IPA_URL=`expo url:ipa`
             curl -X POST --data-urlencode "payload={\"username\": \"circlebot\", \"text\": \"Standalone iOS build $IOS_BUILD_NUM (channel $EXPO_RELEASE_CHANNEL, by user $CIRCLE_USERNAME) is ready to upload: $IPA_URL \nThis updates the $EXPO_RELEASE_CHANNEL channel to commit $CIRCLE_SHA1. \nBuild output: <$CIRCLE_BUILD_URL>\", \"icon_emoji\": \":gift:\"}" $SLACK_WEBHOOK
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,6 +472,7 @@ jobs:
             expo login -u "$EXPO_USERNAME" -p "$EXPO_PASSWORD"
             export IOS_BUILD_NUM=`cat app.json | python -c "import sys, json; print(json.load(sys.stdin)['expo']['ios']['buildNumber'])"`
             echo "About to build iOS binary $IOS_BUILD_NUM for $EXPO_RELEASE_CHANNEL"
+            expo publish --max-workers 2 --non-interactive --release-channel "$EXPO_RELEASE_CHANNEL"
             expo build:ios --no-publish --non-interactive --release-channel "$EXPO_RELEASE_CHANNEL"
             export IPA_URL=`expo url:ipa`
             curl -X POST --data-urlencode "payload={\"username\": \"circlebot\", \"text\": \"Standalone iOS build $IOS_BUILD_NUM (channel $EXPO_RELEASE_CHANNEL, by user $CIRCLE_USERNAME) is ready to upload: $IPA_URL \nThis updates the $EXPO_RELEASE_CHANNEL channel to commit $CIRCLE_SHA1. \nBuild output: <$CIRCLE_BUILD_URL>\", \"icon_emoji\": \":gift:\"}" $SLACK_WEBHOOK


### PR DESCRIPTION
Four Sniffles build attempts in a row failed because the `expo build:ios` step would get stuck during publish and then timeout after 10 minutes. (https://circleci.com/gh/AudereNow/audere/621 as well as builds 617, 618, 619)

Previously when `expo publish` hung during the publish, we added the `--max-workers 2` switch which fixed that. See FEV-598 or https://github.com/AudereNow/learn/pull/1132 
The problem is that `expo build:ios` doesn't recognize the `--max-workers` switch. 

Fixed this by breaking up `expo build:ios` (which does publish then build binary) into `expo publish --max-workers 2` and then `expo build:ios --no-publish`. 

