### PR TITLE
FEV-1130 Add PII question to cough photos expert read form

### DIFF
--- a/FluApi/db/migrations/nonpii/20190905193624-add-contains-pii.js
+++ b/FluApi/db/migrations/nonpii/20190905193624-add-contains-pii.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 by Audere
+//
+// Use of this source code is governed by an MIT-style license that
+// can be found in the LICENSE file distributed with this file.
+
+'use strict';
+
+const { baseColumns, column, foreignIdKey } = require("../../util");
+const schema = "cough";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable(
+      "pii_reviews",
+      {
+        ...baseColumns(Sequelize),
+        surveyId: foreignIdKey(Sequelize, {
+          tableName: "current_surveys",
+          schema: "cough"
+        }),
+        containsPii: column(Sequelize.BOOLEAN),
+        reviewerId: column(Sequelize.INTEGER),
+      },
+      { schema }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable({ tableName: "pii_reviews", schema });
+  }
+};

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -206,13 +206,22 @@ export class RDTPhotos {
   };
 
   public setExpertRead = async (req, res) => {
-    const { surveyId, interpretation } = req.body;
+    const { surveyId, interpretation, piiReview } = req.body;
     const interpreterId = req.user.id;
-    await this.models.expertRead.upsert({
-      surveyId,
-      interpretation,
-      interpreterId,
-    });
+    if (interpretation !== undefined) {
+      await this.models.expertRead.upsert({
+        surveyId,
+        interpretation,
+        interpreterId,
+      });
+    }
+    if (piiReview !== undefined) {
+      await this.models.piiReview.upsert({
+        surveyId,
+        containsPii: piiReview,
+        reviewerId: interpreterId,
+      });
+    }
     res.redirect(303, `./coughPhoto?id=${surveyId}`);
   };
 

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -261,13 +261,14 @@ export class RDTPhotos {
       }
     }
     if (piiReview !== undefined) {
+      const containsPii = JSON.parse(piiReview);
       const oldReview = await this.models.piiReview.findOne({
         where: { surveyId },
       });
-      if (!oldReview || oldReview.containsPii !== piiReview) {
+      if (!oldReview || oldReview.containsPii !== containsPii) {
         await this.models.piiReview.upsert({
           surveyId,
-          containsPii: piiReview,
+          containsPii,
           reviewerId: interpreterId,
         });
       }

--- a/FluApi/src/endpoints/webPortal/rdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/rdtPhotos.ts
@@ -169,7 +169,7 @@ export class RDTPhotos {
       interpretation => ({
         value: interpretation,
         label: INTERPRETATIONS[interpretation],
-        checked: oldInterpretation === interpretation ? "checked" : "",
+        checked: checked(oldInterpretation === interpretation),
       })
     );
 
@@ -177,6 +177,21 @@ export class RDTPhotos {
       req.user.userid,
       Permissions.COUGH_RDT_PHOTOS_WRITE
     );
+    const piiReview = await this.models.piiReview.findOne({
+      where: { surveyId: id },
+    });
+    const piiOptions = [
+      {
+        value: "false",
+        label: "No PII",
+        checked: checked(piiReview && !piiReview.containsPii),
+      },
+      {
+        value: "true",
+        label: "Contains PII",
+        checked: checked(piiReview && piiReview.containsPii),
+      },
+    ];
 
     res.render("rdtPhotos.html", {
       photos,
@@ -186,6 +201,7 @@ export class RDTPhotos {
       canReplace,
       canInterpret,
       interpretations,
+      piiOptions,
     });
   };
 
@@ -222,4 +238,8 @@ export class RDTPhotos {
     });
     res.redirect(303, `./coughPhoto?id=${surveyId}`);
   };
+}
+
+function checked(c: boolean) {
+  return c ? "checked" : "";
 }

--- a/FluApi/src/endpoints/webPortal/templates/barcodes.html
+++ b/FluApi/src/endpoints/webPortal/templates/barcodes.html
@@ -35,6 +35,11 @@ td {
         <td><a href="{{dateSortLink}}">Date</a></td>
         <td>Time</td>
         <td><a href="{{barcodeSortLink}}">Barcode</a></td>
+        <td>Photo Type</td>
+        <td>Result</td>
+        {{#if shouldShowPII}}
+          <td>Contains PII?</td>
+        {{/if}}
       </thead>
       <tbody>
       {{#each barcodes}}
@@ -42,6 +47,11 @@ td {
           <td>{{date}}</td>
           <td>{{time}}</td>
           <td><a href="{{url}}">{{barcode}}</a></td>
+          <td>{{photo_type}}</td>
+          <td>{{expert_read}}</td>
+          {{#if ../shouldShowPII}}
+            <td>{{pii}}</td>
+          {{/if}}
         </tr>
       {{/each}}
       </tbody>

--- a/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
+++ b/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
@@ -56,6 +56,9 @@ can be found in the LICENSE file distributed with this file.
               <label for="{{value}}">{{label}}</label>
             </div>
           {{/each}}
+          {{#if previousReviewer}}
+            <em>Reviewed by {{previousReviewer}}</em>
+          {{/if}}
           <h4>What result does this test strip indicated?</h4>
           {{#each interpretations}}
             <div>
@@ -63,6 +66,9 @@ can be found in the LICENSE file distributed with this file.
               <label for="{{value}}">{{label}}</label>
             </div>
           {{/each}}
+          {{#if previousInterpreter}}
+            <em>Interpreted by {{previousInterpreter}}</em>
+          {{/if}}
           <div>
             <input type="submit" value="Save"/>
           </div>

--- a/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
+++ b/FluApi/src/endpoints/webPortal/templates/rdtPhotos.html
@@ -49,6 +49,14 @@ can be found in the LICENSE file distributed with this file.
         <form action="./setExpertRead" method="post">
           <input type="hidden" name="_csrf" value="{{csrf}}"/>
           <input type="hidden" name="surveyId" value="{{surveyId}}"/>
+          <h4>Does this photo contain PII?</h4>
+          {{#each piiOptions}}
+            <div>
+              <input type="radio" id="{{value}}" name="piiReview" value="{{value}}" {{checked}} />
+              <label for="{{value}}">{{label}}</label>
+            </div>
+          {{/each}}
+          <h4>What result does this test strip indicated?</h4>
           {{#each interpretations}}
             <div>
               <input type="radio" id="{{value}}" name="interpretation" value="{{value}}" {{checked}} />

--- a/FluApi/src/models/db/cough.ts
+++ b/FluApi/src/models/db/cough.ts
@@ -47,6 +47,14 @@ export function defineCoughModels(sql: SplitSql): CoughModels {
     foreignKey: "cough_survey_id",
     onDelete: "CASCADE",
   });
+  models.survey.hasOne(models.expertRead, {
+    foreignKey: "surveyId",
+    onDelete: "CASCADE",
+  });
+  models.survey.hasOne(models.piiReview, {
+    foreignKey: "surveyId",
+    onDelete: "CASCADE",
+  });
 
   return models;
 }
@@ -167,6 +175,8 @@ export interface SurveyAttributes<Info> {
   docId: string;
   device: DeviceInfo;
   survey: Info;
+  pii_review?: PiiReviewAttributes;
+  expert_read?: ExpertReadAttributes;
   updatedAt?: Date;
   createdAt?: Date;
 }

--- a/FluApi/src/models/db/cough.ts
+++ b/FluApi/src/models/db/cough.ts
@@ -39,6 +39,7 @@ export function defineCoughModels(sql: SplitSql): CoughModels {
     photo: definePhoto(sql),
     photoReplacementLog: definePhotoReplacementLog(sql),
     photoUploadLog: definePhotoUploadLog(sql),
+    piiReview: definePiiReviews(sql),
     survey: defineSurvey(sql.nonPii),
   };
 
@@ -61,6 +62,7 @@ export interface CoughModels {
   photo: Model<PhotoAttributes>;
   photoReplacementLog: Model<PhotoReplacementLogAttributes>;
   photoUploadLog: Model<PhotoUploadLogAttributes>;
+  piiReview: Model<PiiReviewAttributes>;
   survey: Model<SurveyAttributes<SurveyNonPIIInfo>>;
 }
 
@@ -389,6 +391,27 @@ export function definePhotoReplacementLog(
       oldPhotoHash: stringColumn("oldPhotoHash"),
       newPhotoHash: stringColumn("newPhotoHash"),
       replacerId: unique(integerColumn("replacerId")),
+    },
+    { schema }
+  );
+}
+
+// ---------------------------------------------------------------
+
+export interface PiiReviewAttributes {
+  surveyId: number;
+  containsPii: boolean;
+  reviewerId: number;
+}
+
+export function definePiiReviews(sql: SplitSql): Model<PiiReviewAttributes> {
+  return defineModel<PiiReviewAttributes>(
+    sql.nonPii,
+    "pii_reviews",
+    {
+      surveyId: unique(integerColumn("surveyId")),
+      containsPii: stringColumn("containsPii"),
+      reviewerId: booleanColumn("reviewerId"),
     },
     { schema }
   );


### PR DESCRIPTION
Adds the following a question on the cough photo page, and a table to store the results.  Might be unnecessary, but you can answer one question without answering the other, and that was slightly simpler with a separate table:
![image](https://user-images.githubusercontent.com/1070243/64386878-249e5380-cfef-11e9-871b-58f27a79f825.png)

Since it can take some time to manually edit PII out of photos, this allows us to quickly review photos for PII, and only share photos that are known to be clean. Later when photos containing PII get replaced, those surveys can be shared with external partners as well.

This PR also adds columns to the list page showing whether the photo was automatically or manually captured, the expert read result, and whether there's PII. It also forbids access to surveys that contain PII, or have not yet been reviewed for PII, for users who just have the basic `coughPhotosAccess` permission.