### PR TITLE
Filter out empty barcode prefixes

### DIFF
--- a/FluApi/src/endpoints/coughGiftcardApi.ts
+++ b/FluApi/src/endpoints/coughGiftcardApi.ts
@@ -148,9 +148,10 @@ export class CoughGiftcardEndpoint {
     const { barcodePrefixes } = req.body;
     const barcodeValidations = barcodePrefixes
       .split("\n")
+      .map(prefix => prefix.trim())
       .filter(prefix => prefix)
       .map(prefix => ({
-        value: prefix.trim(),
+        value: prefix,
         type: BarcodeValidationType.PREFIX,
       }));
     await this.liveConfig.set("barcodeValidations", barcodeValidations);


### PR DESCRIPTION
Addressing @rightparen's comment in https://github.com/AudereNow/audere/pull/204#discussion_r327376278