### PR TITLE
FEV-1219 Update CircleCI to use XCode 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,7 +483,7 @@ jobs:
       FL_OUTPUT_DIR: output # Fastlane env variable for where it should put output files
       <<: *const
     macos:
-      xcode: 10.2.1
+      xcode: 11.1.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout:


### PR DESCRIPTION
Using the CircleCI Xcode 11.1.0 image to build Chills, to fix the 
```
/Users/distiller/repo/FluStudy_us/ios/Pods/ExpoKit/ios/Exponent/Kernel/Views/EXAppViewController.m:398:10: property 'overrideUserInterfaceStyle' not found on object of type 'EXAppViewController *'; did you mean 'preferredUserInterfaceStyle'?

self.overrideUserInterfaceStyle = [self _userInterfaceStyleForString:userInterfaceStyle];
^
```
build error in https://circleci.com/gh/AudereNow/audere/1044