### PR TITLE
Disable chills api endpoints to fix cough

### DIFF
--- a/FluApi/src/app.ts
+++ b/FluApi/src/app.ts
@@ -349,41 +349,41 @@ export function createInternalApp(config: AppConfig) {
     )
   );
 
-  const chills = new ChillsEndpoint(sql);
-  internalApp.get(
-    "/api/chills/updateDerivedTables",
-    stats("chillsUpdateDerivedTables"),
-    wrap(chills.updateDerivedTables)
-  );
-  internalApp.get(
-    "/api/import/chillsDocuments",
-    stats("importChillsDocuments"),
-    wrap(
-      sqlLock.runIfFree(
-        "/api/import/chillsDocuments",
-        chills.importDocuments,
-        jsonNoOp
-      )
-    )
-  );
-  internalApp.get(
-    "/api/chills/uploadPhotos",
-    stats("chillsUploadPhotos"),
-    wrap(chills.uploadPhotos)
-  );
+  //const chills = new ChillsEndpoint(sql);
+  //internalApp.get(
+  //  "/api/chills/updateDerivedTables",
+  //  stats("chillsUpdateDerivedTables"),
+  //  wrap(chills.updateDerivedTables)
+  //);
+  //internalApp.get(
+  //  "/api/import/chillsDocuments",
+  //  stats("importChillsDocuments"),
+  //  wrap(
+  //    sqlLock.runIfFree(
+  //      "/api/import/chillsDocuments",
+  //      chills.importDocuments,
+  //      jsonNoOp
+  //    )
+  //  )
+  //);
+  //internalApp.get(
+  //  "/api/chills/uploadPhotos",
+  //  stats("chillsUploadPhotos"),
+  //  wrap(chills.uploadPhotos)
+  //);
 
-  const chillsFirebase = new ChillsFirebaseAnalyticsEndpoint(sql);
-  internalApp.get(
-    "/api/import/chillsAnalytics",
-    stats("importChillsAnalytics"),
-    wrap(
-      sqlLock.runIfFree(
-        "/api/import/chillsAnalytics",
-        chillsFirebase.importAnalytics,
-        jsonNoOp
-      )
-    )
-  );
+  //const chillsFirebase = new ChillsFirebaseAnalyticsEndpoint(sql);
+  //internalApp.get(
+  //  "/api/import/chillsAnalytics",
+  //  stats("importChillsAnalytics"),
+  //  wrap(
+  //    sqlLock.runIfFree(
+  //      "/api/import/chillsAnalytics",
+  //      chillsFirebase.importAnalytics,
+  //      jsonNoOp
+  //    )
+  //  )
+  //);
 
   return useOuch(internalApp);
 }


### PR DESCRIPTION
I believe that the chills api is breaking cough giftcards, because we only initialize firebase once:
https://github.com/AudereNow/audere/blob/e7776a8b8da6c78d261f44d1a10d0821df93e5fd/FluApi/src/external/firebase.ts#L176-L189 If chills happens to initialize first, all the queries that are meant for cough hit chills instead. The cough giftcards api checks that the user's doc id exists in firebase before issuing a giftcard, but it won't find the doc ids if it's looking in the chills app.

This PR just disables the chills endpoints because we're not using them yet.

See https://github.com/AudereNow/audere/pull/352 for a real fix