### PR TITLE
Show PII review notes on cough photos list page

### DIFF
--- a/FluApi/src/endpoints/webPortal/coughRdtPhotos.ts
+++ b/FluApi/src/endpoints/webPortal/coughRdtPhotos.ts
@@ -103,6 +103,7 @@ export class CoughRDTPhotos {
           ? "PII"
           : "No PII"
         : "Not Reviewed",
+      piiNotes: survey.pii_review ? survey.pii_review.notes : "",
       expert_read: survey.expert_read
         ? INTERPRETATIONS[survey.expert_read.interpretation]
         : "Not interpreted",

--- a/FluApi/src/endpoints/webPortal/templates/barcodes.html
+++ b/FluApi/src/endpoints/webPortal/templates/barcodes.html
@@ -39,6 +39,7 @@ td {
         <td>Result</td>
         {{#if shouldShowPII}}
           <td>Contains PII?</td>
+          <td>PII Notes</td>
         {{/if}}
       </thead>
       <tbody>
@@ -51,6 +52,7 @@ td {
           <td>{{expert_read}}</td>
           {{#if ../shouldShowPII}}
             <td>{{pii}}</td>
+            <td>{{piiNotes}}</td>
           {{/if}}
         </tr>
       {{/each}}


### PR DESCRIPTION
This PR adds another column on this cough photos list page showing the PII review notes:
![image](https://user-images.githubusercontent.com/1070243/68719121-15dc9b80-0560-11ea-8fe3-5077fb63f329.png)
