### PR TITLE
FEV-1520 Fix regression caused by previous checkin

### DIFF
--- a/FluStudy_us/src/ui/components/Questions.tsx
+++ b/FluStudy_us/src/ui/components/Questions.tsx
@@ -145,10 +145,13 @@ class Questions extends React.PureComponent<Props, State> {
 
   _isAnswerValid = (config: SurveyQuestion) => {
     const answer = this.props.answers.get(config.id);
-    if (this._questionsToValidateRefs.get(config.id)) {
-      return this._questionsToValidateRefs.get(config.id)!.current!.validate();
-    } else if (!answer) {
-      return !config.required;
+    if (
+      this._questionsToValidateRefs.get(config.id) &&
+      this._questionsToValidateRefs.get(config.id)!.current
+    ) {
+      return this._questionsToValidateRefs.get(config.id)!.current.validate();
+    } else if (!config.required) {
+      return true;
     }
     switch (config.type) {
       case SurveyQuestionType.Text:


### PR DESCRIPTION
The previous checkin for FEV-1520 caused two regressions:
1) A required question with SurveyQuestionType.Text wasn't considered valid
2) Showing the zip code field for the first time could crash due to the ref not being set

Verified happy path works as expected with invalid/valid answers.