### PR TITLE
Only draw interpretation results on test area bitmap when in debug mode

### DIFF
--- a/FluStudy_us/android/app/src/main/java/host/exp/exponent/DetectorView.java
+++ b/FluStudy_us/android/app/src/main/java/host/exp/exponent/DetectorView.java
@@ -482,7 +482,7 @@ public class DetectorView extends LinearLayout implements
                 InterpretationResult interpretationResult = InterpretationTracker.interpretResults(filterResults(
                         INTERPRETATION_MINIMUM_CONFIDENCE_TF_OD_API,
                         interpretationDetector.recognizeImage(rdtResult.testArea),
-                        false), rdtResult);
+                        false), rdtResult, activity.isDebug());
 
                 Log.i(TAG, "Phase 2 processing time: " + (SystemClock.uptimeMillis() - interpretationStartTimeMs) + "ms");
 

--- a/FluStudy_us/android/app/src/main/java/host/exp/exponent/tracking/InterpretationTracker.java
+++ b/FluStudy_us/android/app/src/main/java/host/exp/exponent/tracking/InterpretationTracker.java
@@ -5,7 +5,6 @@
 
 package host.exp.exponent.tracking;
 
-import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -28,7 +27,8 @@ public class InterpretationTracker {
     private static final BorderedText borderedText = new BorderedText(12);
 
     public static synchronized DetectorView.InterpretationResult interpretResults(
-            final List<Classifier.Recognition> results, RDTTracker.RDTStillFrameResult rdtResult) {
+            final List<Classifier.Recognition> results, RDTTracker.RDTStillFrameResult rdtResult,
+            boolean drawResults) {
         Log.i(TAG, "tracking interpretation result");
 
         Map<String, Classifier.Recognition> bestResults = new HashMap();
@@ -58,16 +58,16 @@ public class InterpretationTracker {
 
         if (hasLine("control", "notvalid", bestResults)) {
             interpretationResult.control = true;
-            drawLine(bestResults.get("control"), Color.BLUE);
+            drawLineIf(drawResults, bestResults.get("control"), Color.BLUE);
 
             if (hasLine("a-pos", "a-neg", bestResults)) {
                 interpretationResult.testA = true;
-                drawLine(bestResults.get("a-pos"), Color.RED);
+                drawLineIf(drawResults, bestResults.get("a-pos"), Color.RED);
             }
 
             if (hasLine("b-pos", "b-neg", bestResults)) {
                 interpretationResult.testB = true;
-                drawLine(bestResults.get("b-pos"), Color.RED);
+                drawLineIf(drawResults, bestResults.get("b-pos"), Color.RED);
             }
         }
 
@@ -87,7 +87,10 @@ public class InterpretationTracker {
         return p;
     }
 
-    private static void drawLine(Classifier.Recognition recognition, int color) {
+    private static void drawLineIf(boolean draw, Classifier.Recognition recognition, int color) {
+        if (!draw) {
+            return;
+        }
         paint.setColor(color);
         final RectF trackedPos = new RectF(recognition.getLocation());
         canvas.drawRect(trackedPos.left, trackedPos.top, trackedPos.right, trackedPos.bottom, paint);


### PR DESCRIPTION
I realized that we may want to be able to go back and run new phase 2 models on our production images, and so should only do the debug interpretation drawing when in debug mode. Will log the full results from the interpretation phase in a follow up pr so that we could reconstruct this if desired offline