### PR TITLE
Fix column name in chills photo upload log

### DIFF
--- a/FluApi/db/migrations/nonpii/20200117003112-fix-chills-column.js
+++ b/FluApi/db/migrations/nonpii/20200117003112-fix-chills-column.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 by Audere
+//
+// Use of this source code is governed by an MIT-style license that
+// can be found in the LICENSE file distributed with this file.
+
+'use strict';
+
+const schema = "chills";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn({ schema, tableName: "photo_upload_log" }, "cough_survey_id", "chills_survey_id");
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn({ schema, tableName: "photo_upload_log" }, "chills_survey_id", "cough_survey_id");
+  }
+};


### PR DESCRIPTION
Created with a different name here:
https://github.com/AudereNow/audere/blob/d5223c6c14f477eb9a49cf43084bfede3721dcf5/FluApi/db/migrations/nonpii/20191022105323-create-chills-tables.js#L76

Used here:
https://github.com/AudereNow/audere/blob/d5223c6c14f477eb9a49cf43084bfede3721dcf5/FluApi/src/endpoints/chillsApi.ts#L111

Discovered this issue while investigating FEV-1577, but I'm pretty sure it's unrelated.