### PR TITLE
FEV-1659 "Photo captured" screen text diverges

### DIFF
--- a/FluStudy_us/src/i18n/locales/en.json
+++ b/FluStudy_us/src/i18n/locales/en.json
@@ -543,8 +543,10 @@
     "off": "OFF"
   },
   "TestStripConfirmation": {
-    "title": "Photo captured",
-    "desc": "Your test strip photo was captured successfully.",
+    "title": "Test strip captured",
+    "desc": "{{desc}}",
+    "descManual": "Your test strip photo was captured successfully.",
+    "descScanned": "Your test strip was scanned successfully.",
     "diagnosis": "[Demo Mode only] Your test result is {{ testResult }}."
   },
   "PackUpTest": {

--- a/FluStudy_us/src/resources/ScreenConfig.ts
+++ b/FluStudy_us/src/resources/ScreenConfig.ts
@@ -86,6 +86,7 @@ import {
   SMALL_TEXT,
 } from "../ui/styles";
 import {
+  getCapturedScreenTextVariables,
   getPinkWhenBlueNextScreen,
   getTestStripSurveyNextScreen,
   logFluResult,
@@ -947,7 +948,13 @@ export const Screens: ScreenConfig[] = [
     body: [
       { tag: RDTImage },
       { tag: Title },
-      { tag: ScreenText, props: { label: "desc" } },
+      {
+        tag: ScreenText,
+        props: {
+          label: "desc",
+          textVariablesFn: getCapturedScreenTextVariables,
+        },
+      },
       {
         tag: ScreenText,
         props: {

--- a/FluStudy_us/src/util/fluResults.ts
+++ b/FluStudy_us/src/util/fluResults.ts
@@ -6,8 +6,9 @@
 import { Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import { logFirebaseEvent, FunnelEvents } from "./tracker";
-import { getStore } from "../store";
+import { getStore, StoreState } from "../store";
 import { getSelectedButton } from "./survey";
+import i18n from "i18next";
 import {
   BlueLineConfig,
   PinkWhenBlueConfig,
@@ -57,4 +58,21 @@ export async function logFluResult() {
     });
   }
   _previousPinkAnswer = pinkAnswer;
+}
+
+async function didScanMultiple() {
+  const state: StoreState = (await getStore()).getState();
+  const screenJustPrior = state.survey.events.slice(-2, -1)[0].refId || "";
+  return (
+    screenJustPrior === "AndroidRDTReader" &&
+    getRemoteConfig("previewFramesSampleRate") > 0
+  );
+}
+
+export async function getCapturedScreenTextVariables() {
+  return {
+    desc: didScanMultiple()
+      ? i18n.t("TestStripConfirmation:descScanned")
+      : i18n.t("TestStripConfirmation:descManual"),
+  };
 }


### PR DESCRIPTION
For users who go through the new RDT scan with previewFrameRate > 0, we want to change the current message of "Photo captured" and "Your test strip photo was captured successfully." on the confirmation screen, because it conflicts with the preceding message that the app would take multiple photos during the scanning process. 

Originally wanted to change Title to "Scanning complete", but that would require adding the textVariablesFn instrumentation into Title. So instead using "Test strip captured" title for either case. 

Note: This is not perfect because if the user tries RDT scan but fails, and takes a photo, we just show them "Photo captured" and "Your test strip photo was captured successfully." But can't think of better text to show in this case. 