### PR TITLE
Add missing parameter in iOS to RN bridge method add()

### DIFF
--- a/FluStudy_us/ios/fluathome/FirebaseStorageUploadModule.mm
+++ b/FluStudy_us/ios/fluathome/FirebaseStorageUploadModule.mm
@@ -42,6 +42,7 @@ RCT_REMAP_METHOD(add,
                  queue:(NSString *)queue
                  uid:(NSString *)uid
                  uriString:(NSString *)uriString
+                 removeOriginal:(BOOL)removeOriginal
                  addWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
     RCTLogInfo(@"add queue=%@ uid=%@ uri=%@", queue, uid, uriString);
@@ -60,6 +61,10 @@ RCT_REMAP_METHOD(add,
     if (error != nil) {
         reject(@"", @"", error);
         return;
+    }
+    
+    if (removeOriginal) {
+        [self->fileManager removeItemAtPath:uriString error:&error];
     }
 
     resolve(nil);


### PR DESCRIPTION
Forgot to add the new removeOriginal parameter to the iOS implementation of add() in https://github.com/AudereNow/audere/pull/589