### PR TITLE
Process frames after user agrees to start scan

### DIFF
--- a/FluStudy_us/android/app/src/main/java/host/exp/exponent/DetectorView.java
+++ b/FluStudy_us/android/app/src/main/java/host/exp/exponent/DetectorView.java
@@ -92,6 +92,8 @@ public class DetectorView extends LinearLayout implements
     private volatile boolean stillCaptureInProgress = false;
     private volatile int previewFrameIndex = 0;
 
+    private boolean processFrames = false;
+
     public DetectorView(Context context, AttributeSet attrs) {
         super(context, attrs);
         if (context instanceof MainActivity) {
@@ -115,6 +117,10 @@ public class DetectorView extends LinearLayout implements
         } else {
             requestPermission();
         }
+    }
+
+    public void setProcessFrames(boolean processFrames) {
+        this.processFrames = processFrames;
     }
 
     public void setDetectorListener(DetectorListener listener) {
@@ -372,7 +378,7 @@ public class DetectorView extends LinearLayout implements
 
         private void processImage() {
             // No mutex needed as this method is not reentrant.
-            if (analyzingFrame) {
+            if (analyzingFrame || !processFrames) {
                 readyForNextImage();
                 return;
             }

--- a/FluStudy_us/android/app/src/main/java/host/exp/exponent/RDTReader.java
+++ b/FluStudy_us/android/app/src/main/java/host/exp/exponent/RDTReader.java
@@ -26,10 +26,12 @@ import host.exp.exponent.tracking.RDTTracker;
 public class RDTReader extends LinearLayout implements DetectorView.DetectorListener {
     private Activity mActivity;
     private DetectorView detectorView;
+    private boolean processFrames;
 
     public RDTReader(Context context, Activity activity) {
         super(context);
         mActivity = activity;
+        processFrames = false;
     }
 
     public void enable() {
@@ -41,6 +43,7 @@ public class RDTReader extends LinearLayout implements DetectorView.DetectorList
 
                 detectorView = findViewById(R.id.detector_view);
                 detectorView.setDetectorListener(self);
+                detectorView.setProcessFrames(self.processFrames);
                 requestLayout();
             }
         });
@@ -193,6 +196,15 @@ public class RDTReader extends LinearLayout implements DetectorView.DetectorList
     public void setFlashEnabled(boolean flashEnabled) {
         if (detectorView != null) {
             detectorView.setFlashEnabled(flashEnabled);
+        }
+    }
+
+    public void setProcessFrames(boolean processFrames) {
+        // Can't guarantee call order for the RN prop variables, so we'll store a local
+        // copy to initialize the detectorView with if it gets created later
+        this.processFrames = processFrames;
+        if (detectorView != null) {
+            detectorView.setProcessFrames(processFrames);
         }
     }
 }

--- a/FluStudy_us/android/app/src/main/java/host/exp/exponent/RDTReaderManager.java
+++ b/FluStudy_us/android/app/src/main/java/host/exp/exponent/RDTReaderManager.java
@@ -65,4 +65,9 @@ public class RDTReaderManager extends SimpleViewManager<RDTReader> {
             view.onPause();
         }
     }
+
+    @ReactProp(name = "processFrames")
+    public void setDoAnalysis(RDTReader view, boolean processFrames) {
+        view.setProcessFrames(processFrames);
+    }
 }

--- a/FluStudy_us/src/native/rdtReader.tsx
+++ b/FluStudy_us/src/native/rdtReader.tsx
@@ -67,6 +67,7 @@ type RDTReaderProps = {
   showDefaultViewfinder?: boolean;
   frameImageScale: number;
   appState: string;
+  processFrames: boolean;
   style: any;
 };
 

--- a/FluStudy_us/src/ui/components/flu/AndroidRDTReader.tsx
+++ b/FluStudy_us/src/ui/components/flu/AndroidRDTReader.tsx
@@ -312,13 +312,13 @@ class AndroidRDTReader extends React.Component<Props & WithNamespaces, State> {
 
   _startRecordingFrames = () => {
     this.setState({ processFrames: true });
+    this._setTimer();
     const { dispatch } = this.props;
     dispatch(setRDTStartTime());
   };
 
   _handleDidFocus = () => {
     this._saveAndClearPreviewFrames();
-    this._setTimer();
     if (this.props.isDemo && !this._fpsCounterInterval) {
       this._fpsCounterInterval = global.setInterval(
         this._updateFPSCounter,


### PR DESCRIPTION
Changes the control flow for the reader to first open the RDT reader and initialize the camera, then (if sample rate > 0) show the 'start scan' dialog, then finally begin processing the frames. This way the user can see their strip underneath the dialog before they hit start (but we are not capturing anything before they explicitly begin the scan)